### PR TITLE
Add zone map to neiborhood finder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,7 @@ GEONAME_CLIENT_ID=
 
 DEBUG=true
 
+REACT_APP_MAPBOX_TOKEN=
+
 # To add to a heroku app, for each variable:
 # heroku config:set NAME=VALUE

--- a/app.json
+++ b/app.json
@@ -33,6 +33,9 @@
     },
     "APP_NAME": {
       "description": "Name of your organization (Crown Heights Mutual Aid)"
+    },
+    "REACT_APP_MAPBOX_TOKEN": {
+      "description": "Mapbox token for client side map. Can be found on https://account.mapbox.com/"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mutual-aid-slack",
+  "name": "mutual-aid-app",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -1996,6 +1996,68 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
+      "requires": {
+        "wgs84": "0.0.0"
+      }
+    },
+    "@mapbox/geojson-rewind": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
+      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
+      "requires": {
+        "@mapbox/geojson-area": "0.2.2",
+        "concat-stream": "~1.6.0",
+        "minimist": "^1.2.5",
+        "sharkdown": "^0.1.0"
+      }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+    },
+    "@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "@mapbox/tiny-sdf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
+      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
+    "@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "requires": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
     "@material-ui/core": {
       "version": "4.9.7",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.7.tgz",
@@ -2508,6 +2570,24 @@
         "loader-utils": "^1.2.3"
       }
     },
+    "@turf/bbox": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-4.7.3.tgz",
+      "integrity": "sha1-461PEKfptBtSKIDTMIMZgZkFkGc=",
+      "requires": {
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/helpers": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-4.7.3.tgz",
+      "integrity": "sha1-vDEqxDyrPFMqSDFRxMOCxWSUKek="
+    },
+    "@turf/meta": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-4.7.4.tgz",
+      "integrity": "sha1-beLx6YkLj2S2aeS0fAmyCJMGOXc="
+    },
     "@types/babel__core": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -2600,6 +2680,11 @@
         "@types/node": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -2750,6 +2835,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/supercluster": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-5.0.2.tgz",
+      "integrity": "sha512-5PONNyiZXHS6oiW0H1rsNQ+Apkg+cqp3jP4HRhCAcgASIj3ifrFsdj1QB5TvArqT5N8RetK6UH7873COgRZwoQ==",
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/yargs": {
       "version": "13.0.8",
@@ -3164,6 +3257,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "anymatch": {
       "version": "2.0.0",
@@ -4170,6 +4268,15 @@
         "rsvp": "^4.8.4"
       }
     },
+    "cardinal": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "redeyed": "~0.4.0"
+      }
+    },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
@@ -4900,6 +5007,11 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
       "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw=="
     },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+    },
     "cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
@@ -5473,6 +5585,11 @@
           }
         }
       }
+    },
+    "earcut": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
+      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -6963,6 +7080,11 @@
       "resolved": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
       "integrity": "sha1-6P+0yBwKdbPjBvUYcmXW8jBA9Qs="
     },
+    "geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "geonames.js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/geonames.js/-/geonames.js-2.3.0.tgz",
@@ -7007,6 +7129,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
     },
     "glob": {
       "version": "7.1.6",
@@ -7103,6 +7230,11 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+    },
+    "grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "growl": {
       "version": "1.10.5",
@@ -9302,6 +9434,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -9624,6 +9761,43 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mapbox-gl": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.9.1.tgz",
+      "integrity": "sha512-jpBcqh+4qpOkj8RdxRdvwKPA8gzNYyMQ8HOcXgZYuEM5nKevRDjD3cEs+rUxi1JuYj4t8bIk68Lfh7aQQC1MjQ==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.2",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.0.0",
+        "grid-index": "^1.1.0",
+        "minimist": "0.0.8",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.0.0",
+        "tinyqueue": "^2.0.0",
+        "vt-pbf": "^3.1.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "md5.js": {
@@ -10111,6 +10285,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -10860,6 +11039,15 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
         "pify": "^3.0.0"
+      }
+    },
+    "pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {
@@ -11894,6 +12082,11 @@
         "uniq": "^1.0.1"
       }
     },
+    "potpack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -12003,6 +12196,11 @@
         "react-is": "^16.8.1"
       }
     },
+    "protocol-buffers-schema": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -12104,6 +12302,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "raf": {
       "version": "3.4.1",
@@ -12418,6 +12621,25 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-mapbox-gl": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/react-mapbox-gl/-/react-mapbox-gl-4.8.3.tgz",
+      "integrity": "sha512-o5PrNjIyvF04G77/pWfHJI5G9yM4/IUEsNfGhyC5DTm+Ye/b61jJMAt1A6WLClpWeBXnDY5W7eVC6A2INMbgVA==",
+      "requires": {
+        "@turf/bbox": "4.7.3",
+        "@turf/helpers": "4.7.3",
+        "@types/supercluster": "^5.0.1",
+        "deep-equal": "1.0.1",
+        "supercluster": "^7.0.0"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+        }
+      }
+    },
     "react-scripts": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.0.tgz",
@@ -12726,6 +12948,21 @@
         "minimatch": "3.0.4"
       }
     },
+    "redeyed": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
+      "requires": {
+        "esprima": "~1.0.4"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        }
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -12984,6 +13221,14 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -13146,6 +13391,11 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
       "version": "6.5.4",
@@ -13458,6 +13708,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
+    "sharkdown": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
+      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
+      "requires": {
+        "cardinal": "~0.4.2",
+        "minimist": "0.0.5",
+        "split": "~0.2.10"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -13776,6 +14043,14 @@
         "obuf": "^1.1.2",
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
+      }
+    },
+    "split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+      "requires": {
+        "through": "2"
       }
     },
     "split-on-first": {
@@ -14124,6 +14399,14 @@
         }
       }
     },
+    "supercluster": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.0.0.tgz",
+      "integrity": "sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==",
+      "requires": {
+        "kdbush": "^3.0.0"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -14399,6 +14682,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -14814,6 +15102,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "vt-pbf": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
+      "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
+      "requires": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.0.5"
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -16417,6 +16715,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+    },
+    "wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "i18next": "^19.3.3",
     "i18next-node-fs-backend": "^2.1.3",
     "lodash": "^4.17.15",
+    "mapbox-gl": "^1.9.1",
     "mocha": "^7.1.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-helmet": "^5.2.1",
+    "react-mapbox-gl": "^4.8.3",
     "react-scripts": "3.4.0"
   },
   "devDependencies": {

--- a/src/api/geo.js
+++ b/src/api/geo.js
@@ -30,14 +30,18 @@ exports.addressHandler = async (req, res, next) => {
     const geoResults = geoResult.data.results;
 
     const locResult = geoResults[0];
+    const {
+      geometry: { location }
+    } = locResult;
+
     const neighborhood = locResult.address_components.find(component =>
       component.types.includes("neighborhood")
     );
+
     const neighborhoodName = neighborhood ? neighborhood.long_name : "";
-    const [lt, long] = [
-      locResult.geometry.location.lat,
-      locResult.geometry.location.lng
-    ];
+
+    const [lt, long] = [location.lat, location.lng];
+
     const intersection = await geonamesClient.findNearestIntersection({
       lat: lt,
       lng: long
@@ -53,6 +57,7 @@ exports.addressHandler = async (req, res, next) => {
     return res.end(
       JSON.stringify({
         neighborhoodName,
+        location,
         intersection: {
           street_1: intersection.intersection.street1,
           street_2: intersection.intersection.street2

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -1,0 +1,67 @@
+import React from "react";
+import ReactMapboxGl, { Feature, Layer, Source } from "react-mapbox-gl";
+import quadrantsGeoJSON from "../../assets/crownheights.json";
+
+const CROWN_HEIGHTS_CENTER_COORD = [-73.943018, 40.671254];
+
+const MapboxMap = ReactMapboxGl({
+  accessToken:
+    "pk.eyJ1IjoicGlyYXRlZnNoIiwiYSI6ImNrOGppNWJpcTBoM2wzbnIwb3kxcmNlcWYifQ.B8cTgg45CTfcEwSdOfHXrQ"
+});
+
+const QuadrantMap = ({ location }) => {
+  return (
+    <MapboxMap
+      style="mapbox://styles/mapbox/streets-v9"
+      center={CROWN_HEIGHTS_CENTER_COORD}
+      containerStyle={{
+        height: "300px",
+        width: "500px"
+      }}
+      zoom={[12]}
+    >
+      <Source
+        id="quadrants_src"
+        geoJsonSource={{
+          type: "geojson",
+          data: quadrantsGeoJSON
+        }}
+      />
+
+      <Layer
+        sourceId="quadrants_src"
+        type="fill"
+        paint={{
+          "fill-color": {
+            type: "identity",
+            property: "fill"
+          },
+          "fill-opacity": 0.4
+        }}
+      />
+      <Layer
+        sourceId="quadrants_src"
+        type="symbol"
+        layout={{
+          "text-field": {
+            type: "identity",
+            property: "id"
+          },
+          "text-size": 20
+        }}
+      />
+
+      {location && (
+        <Layer
+          type="symbol"
+          id="marker"
+          layout={{ "icon-image": "star-15", "icon-size": 1.5 }}
+        >
+          <Feature coordinates={[location.lng, location.lat]} />
+        </Layer>
+      )}
+    </MapboxMap>
+  );
+};
+
+export default QuadrantMap;

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -36,8 +36,8 @@ const QuadrantMap = ({ location }) => {
       style="mapbox://styles/mapbox/bright-v9"
       center={CROWN_HEIGHTS_CENTER_COORD}
       containerStyle={{
-        height: "300px",
-        width: "500px"
+        height: "350px",
+        width: "100%"
       }}
       fitBounds={bounds}
       fitBoundsOptions={{

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -20,10 +20,21 @@ const CROWN_HEIGHTS_BOUNDS = findBounds(
 );
 
 const CROWN_HEIGHTS_CENTER_COORD = new LngLat(-73.943018, 40.671254);
+const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 
-const MapboxMap = ReactMapboxGl({
-  accessToken: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN
-});
+const MapboxMap = MAPBOX_TOKEN
+  ? ReactMapboxGl({
+      accessToken: MAPBOX_TOKEN
+    })
+  : () => (
+    <div>
+      Mapbox token is missing. This means that the map cannot be displayed,
+      but should not affect the functionality of the page. Please inform
+      <a href="https://crownheightsmutualaid.slack.com/archives/C010AUQ6DFD">
+        #tech.
+      </a>
+    </div>
+    );
 
 const QuadrantMap = ({ location }) => {
   const lnglat = location && new LngLat(location.lng, location.lat);

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -44,7 +44,7 @@ const QuadrantMap = ({ location }) => {
             type: "identity",
             property: "fill"
           },
-          "fill-opacity": 0.4
+          "fill-opacity": 0.25
         }}
       />
 

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -5,8 +5,7 @@ import quadrantsGeoJSON from "../../assets/crownheights.json";
 const CROWN_HEIGHTS_CENTER_COORD = [-73.943018, 40.671254];
 
 const MapboxMap = ReactMapboxGl({
-  accessToken:
-    "pk.eyJ1IjoicGlyYXRlZnNoIiwiYSI6ImNrOGppNWJpcTBoM2wzbnIwb3kxcmNlcWYifQ.B8cTgg45CTfcEwSdOfHXrQ"
+  accessToken: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN
 });
 
 const QuadrantMap = ({ location }) => {

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -1,5 +1,10 @@
 import React from "react";
-import ReactMapboxGl, { Feature, Layer, Source, ZoomControl } from "react-mapbox-gl";
+import ReactMapboxGl, {
+  Feature,
+  Layer,
+  Source,
+  ZoomControl
+} from "react-mapbox-gl";
 import quadrantsGeoJSON from "../../assets/crownheights.json";
 
 const CROWN_HEIGHTS_CENTER_COORD = [-73.943018, 40.671254];
@@ -19,8 +24,9 @@ const QuadrantMap = ({ location }) => {
       }}
       zoom={[12]}
     >
-      <ZoomControl/>
+      <ZoomControl />
 
+      {/* load geojson source */}
       <Source
         id="quadrants_src"
         geoJsonSource={{
@@ -29,6 +35,7 @@ const QuadrantMap = ({ location }) => {
         }}
       />
 
+      {/* fill quadrants */}
       <Layer
         sourceId="quadrants_src"
         type="fill"
@@ -40,6 +47,8 @@ const QuadrantMap = ({ location }) => {
           "fill-opacity": 0.4
         }}
       />
+
+      {/* label quadrants */}
       <Layer
         sourceId="quadrants_src"
         type="symbol"
@@ -52,6 +61,7 @@ const QuadrantMap = ({ location }) => {
         }}
       />
 
+      {/* display marker for current address if exists */}
       {location && (
         <Layer
           type="symbol"

--- a/src/webapp/components/QuadrantMap.js
+++ b/src/webapp/components/QuadrantMap.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactMapboxGl, { Feature, Layer, Source } from "react-mapbox-gl";
+import ReactMapboxGl, { Feature, Layer, Source, ZoomControl } from "react-mapbox-gl";
 import quadrantsGeoJSON from "../../assets/crownheights.json";
 
 const CROWN_HEIGHTS_CENTER_COORD = [-73.943018, 40.671254];
@@ -11,7 +11,7 @@ const MapboxMap = ReactMapboxGl({
 const QuadrantMap = ({ location }) => {
   return (
     <MapboxMap
-      style="mapbox://styles/mapbox/streets-v9"
+      style="mapbox://styles/mapbox/bright-v9"
       center={CROWN_HEIGHTS_CENTER_COORD}
       containerStyle={{
         height: "300px",
@@ -19,6 +19,8 @@ const QuadrantMap = ({ location }) => {
       }}
       zoom={[12]}
     >
+      <ZoomControl/>
+
       <Source
         id="quadrants_src"
         geoJsonSource={{

--- a/src/webapp/helpers/mapbox-coordinates.js
+++ b/src/webapp/helpers/mapbox-coordinates.js
@@ -1,0 +1,18 @@
+import { LngLat } from "mapbox-gl";
+
+const isValidLngLat = c => c instanceof LngLat;
+
+const findBounds = rawCoords => {
+  const coords = rawCoords.filter(c => isValidLngLat(c));
+  // find min and max lng
+  const minLng = Math.min(...coords.map(c => c.lng));
+  const maxLng = Math.max(...coords.map(c => c.lng));
+
+  // find min and max lat
+  const minLat = Math.min(...coords.map(c => c.lat));
+  const maxLat = Math.max(...coords.map(c => c.lat));
+
+  return [new LngLat(minLng, minLat), new LngLat(maxLng, maxLat)];
+};
+
+export { isValidLngLat, findBounds };

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -103,7 +103,7 @@ export default function NeighborhoodFinder() {
     <Box className={classes.root}>
       <Box className={classes.formRoot}>
         <Box>
-          <Typography className={classes.text} variant="h3">
+          <Typography className={classes.text} variant="h4">
             Crown Heights Neighbourhood Finder
           </Typography>
           <Typography className={classes.text} variant="body1">

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => ({
     paddingRight: theme.spacing(3),
     width: "100%",
     [theme.breakpoints.up("md")]: {
-      width: "55%"
+      display: "flex"
     }
   },
   field: {
@@ -38,6 +38,12 @@ const useStyles = makeStyles(theme => ({
   },
   text: {
     marginBottom: theme.spacing(1)
+  },
+  mapRoot: {
+    flex: 1
+  },
+  formRoot: {
+    flex: 1
   }
 }));
 
@@ -95,94 +101,102 @@ export default function NeighborhoodFinder() {
 
   return (
     <Box className={classes.root}>
-      <Typography className={classes.text} variant="body1">
-        Enter an address and we will look up cross streets and the neighborhood.
-      </Typography>
-      <Typography className={classes.text} variant="body1">
-        For best results, enter street and town (Ex: 1550 dean st brooklyn)
-      </Typography>
-      <Typography className={classes.text} variant="body1">
-        The address will not be stored or logged :)
-      </Typography>
-
-      <QuadrantMap location={data && data.location} />
-
-      <form onSubmit={handleSubmit} autoComplete="off">
-        <TextField
-          id="address"
-          name="address"
-          label="Address"
-          type="text"
-          margin="normal"
-          variant="outlined"
-          required
-          onChange={e => setAddress(e.target.value)}
-          className={classes.field}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <Button aria-label="address-submit" onClick={handleSubmit}>
-                  Submit
-                </Button>
-              </InputAdornment>
-            )
-          }}
-        />
-      </form>
-
-      {data && (
-        <>
-          <TextField
-            disabled
-            id="cross-1"
-            label="Cross Street #1"
-            value={data.intersection.street_1}
-            variant="outlined"
-            className={classes.field}
-          />
-          <TextField
-            disabled
-            id="cross-2"
-            label="Cross Street #2"
-            value={data.intersection.street_2}
-            variant="outlined"
-            className={classes.field}
-          />
-          <TextField
-            disabled
-            id="neighborhood"
-            label="Neighborhood"
-            value={data.neighborhoodName || "Unavailable"}
-            helperText="If both this and zone are unavailable, double check the map: https://bit.ly/2UrZPkA"
-            variant="outlined"
-            className={classes.field}
-          />
-          <TextField
-            disabled
-            id="zone"
-            label="Crown Heights Volunteer Zone"
-            value={data.quadrant || "Unavailable"}
-            variant="outlined"
-            className={classes.field}
-          />
-          <Divider className={classes.divider} />
-          <EmailButton />
-        </>
-      )}
-      {loading && <CircularProgress />}
-      {error && (
-        <>
-          <Typography className={classes.text} variant="body1">
-            Error loading. Please try again. If it fails again, let us know in
-            &nbsp;
-            <a href="https://crownheightsmutualaid.slack.com/archives/C010AUQ6DFD">
-              #tech.
-            </a>
+      <Box className={classes.formRoot}>
+        <Box>
+          <Typography className={classes.text} variant="h3">
+            Crown Heights Neighbourhood Finder
           </Typography>
-          <Divider className={classes.divider} />
-          <EmailButton />
-        </>
-      )}
+          <Typography className={classes.text} variant="body1">
+            Enter an address and we will look up cross streets and the neighborhood.
+          </Typography>
+          <Typography className={classes.text} variant="body1">
+            For best results, enter street and town (Ex: 1550 dean st brooklyn)
+          </Typography>
+          <Typography className={classes.text} variant="body1">
+            The address will not be stored or logged :)
+          </Typography>
+        </Box>
+        <form onSubmit={handleSubmit} autoComplete="off">
+          <TextField
+            id="address"
+            name="address"
+            label="Address"
+            type="text"
+            margin="normal"
+            variant="outlined"
+            required
+            onChange={e => setAddress(e.target.value)}
+            className={classes.field}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Button aria-label="address-submit" onClick={handleSubmit}>
+                    Submit
+                  </Button>
+                </InputAdornment>
+              )
+            }}
+          />
+        </form>
+
+        {data && (
+          <>
+            <TextField
+              disabled
+              id="cross-1"
+              label="Cross Street #1"
+              value={data.intersection.street_1}
+              variant="outlined"
+              className={classes.field}
+            />
+            <TextField
+              disabled
+              id="cross-2"
+              label="Cross Street #2"
+              value={data.intersection.street_2}
+              variant="outlined"
+              className={classes.field}
+            />
+            <TextField
+              disabled
+              id="neighborhood"
+              label="Neighborhood"
+              value={data.neighborhoodName || "Unavailable"}
+              helperText="If both this and zone are unavailable, double check the map: https://bit.ly/2UrZPkA"
+              variant="outlined"
+              className={classes.field}
+            />
+            <TextField
+              disabled
+              id="zone"
+              label="Crown Heights Volunteer Zone"
+              value={data.quadrant || "Unavailable"}
+              variant="outlined"
+              className={classes.field}
+            />
+            <Divider className={classes.divider} />
+            <EmailButton />
+          </>
+        )}
+        {loading && <CircularProgress />}
+        {error && (
+          <>
+            <Typography className={classes.text} variant="body1">
+              Error loading. Please try again. If it fails again, let us know in
+              &nbsp;
+              <a href="https://crownheightsmutualaid.slack.com/archives/C010AUQ6DFD">
+                #tech.
+              </a>
+            </Typography>
+            <Divider className={classes.divider} />
+            <EmailButton />
+          </>
+        )}
+      </Box>
+
+      <Box className={classes.mapRoot}>
+        <QuadrantMap location={data && data.location} />
+      </Box>
     </Box>
   );
 }

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-
 import useAxios from "axios-hooks";
 import { makeStyles } from "@material-ui/core/styles";
 import { CircularProgress } from "@material-ui/core";
@@ -10,15 +9,7 @@ import MailOutlineIcon from "@material-ui/icons/MailOutline";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import Button from "@material-ui/core/Button";
 import Divider from "@material-ui/core/Divider";
-import ReactMapboxGl, { GeoJSONLayer, Layer, Source } from "react-mapbox-gl";
-import quadrantsGeoJSON from "../../assets/crownheights.json";
-
-const Map = ReactMapboxGl({
-  accessToken:
-    "pk.eyJ1IjoicGlyYXRlZnNoIiwiYSI6ImNrOGppNWJpcTBoM2wzbnIwb3kxcmNlcWYifQ.B8cTgg45CTfcEwSdOfHXrQ"
-});
-
-const CROWN_HEIGHTS_CENTER_COORD = [-73.943018, 40.671254];
+import QuadrantMap from "../components/QuadrantMap";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -114,46 +105,7 @@ export default function NeighborhoodFinder() {
         The address will not be stored or logged :)
       </Typography>
 
-      <Map
-        style="mapbox://styles/mapbox/streets-v9"
-        center={CROWN_HEIGHTS_CENTER_COORD}
-        containerStyle={{
-          height: "300px",
-          width: "500px"
-        }}
-        zoom={[12]}
-      >
-        <Source
-          id="quadrants_src"
-          geoJsonSource={{
-            type: "geojson",
-            data: quadrantsGeoJSON
-          }}
-        />
-
-        <Layer
-          sourceId="quadrants_src"
-          type="fill"
-          paint={{
-            "fill-color": {
-              type: "identity",
-              property: "fill"
-            },
-            "fill-opacity": 0.4
-          }}
-        />
-        <Layer
-          sourceId="quadrants_src"
-          type="symbol"
-          layout={{
-            "text-field": {
-              type: "identity",
-              property: "id"
-            },
-            "text-size": 20
-          }}
-        />
-      </Map>
+      <QuadrantMap location={data && data.location} />
 
       <form onSubmit={handleSubmit} autoComplete="off">
         <TextField

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -123,20 +123,34 @@ export default function NeighborhoodFinder() {
         }}
         zoom={[12]}
       >
-        <Source id="quadrants_src" geoJsonSource={{
-          type: "geojson",
-          data: quadrantsGeoJSON
-        }} />
+        <Source
+          id="quadrants_src"
+          geoJsonSource={{
+            type: "geojson",
+            data: quadrantsGeoJSON
+          }}
+        />
 
         <Layer
           sourceId="quadrants_src"
           type="fill"
           paint={{
-            'fill-color': {
-              type: 'identity',
-              property: 'fill'
+            "fill-color": {
+              type: "identity",
+              property: "fill"
             },
-            'fill-opacity': 0.3
+            "fill-opacity": 0.4
+          }}
+        />
+        <Layer
+          sourceId="quadrants_src"
+          type="symbol"
+          layout={{
+            "text-field": {
+              type: "identity",
+              property: "id"
+            },
+            "text-size": 20
           }}
         />
       </Map>

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -10,6 +10,15 @@ import MailOutlineIcon from "@material-ui/icons/MailOutline";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import Button from "@material-ui/core/Button";
 import Divider from "@material-ui/core/Divider";
+import ReactMapboxGl, { GeoJSONLayer, Layer, Source } from "react-mapbox-gl";
+import quadrantsGeoJSON from "../../assets/crownheights.json";
+
+const Map = ReactMapboxGl({
+  accessToken:
+    "pk.eyJ1IjoicGlyYXRlZnNoIiwiYSI6ImNrOGppNWJpcTBoM2wzbnIwb3kxcmNlcWYifQ.B8cTgg45CTfcEwSdOfHXrQ"
+});
+
+const CROWN_HEIGHTS_CENTER_COORD = [-73.943018, 40.671254];
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -104,6 +113,34 @@ export default function NeighborhoodFinder() {
       <Typography className={classes.text} variant="body1">
         The address will not be stored or logged :)
       </Typography>
+
+      <Map
+        style="mapbox://styles/mapbox/streets-v9"
+        center={CROWN_HEIGHTS_CENTER_COORD}
+        containerStyle={{
+          height: "300px",
+          width: "500px"
+        }}
+        zoom={[12]}
+      >
+        <Source id="quadrants_src" geoJsonSource={{
+          type: "geojson",
+          data: quadrantsGeoJSON
+        }} />
+
+        <Layer
+          sourceId="quadrants_src"
+          type="fill"
+          paint={{
+            'fill-color': {
+              type: 'identity',
+              property: 'fill'
+            },
+            'fill-opacity': 0.3
+          }}
+        />
+      </Map>
+
       <form onSubmit={handleSubmit} autoComplete="off">
         <TextField
           id="address"


### PR DESCRIPTION
Closes https://github.com/crownheightsaid/mutual-aid-app/issues/7

## Changes
Displays quadrant map and a marker of current address entered. Handles cases where address entered is outside of Crown Heights.

Sorry its kinda ugly right now, I'm just using whatever mapbox style is available. I chose mapbox only because historically it has a more flexible API to work with and is better documented.

### Default state:
<img width="1285" alt="Screen Shot 2020-04-04 at 12 51 25 PM" src="https://user-images.githubusercontent.com/1868400/78456684-1e4e8380-7673-11ea-9898-306db54ede0d.png">


### Address (in Crown Heights) entered:
<img width="1274" alt="Screen Shot 2020-04-04 at 12 52 58 PM" src="https://user-images.githubusercontent.com/1868400/78456713-43db8d00-7673-11ea-9d17-bdfdeccb04db.png">

### Address (outside of CH):
Zooms to fit bounds with address marker
<img width="1274" alt="Screen Shot 2020-04-04 at 12 53 14 PM" src="https://user-images.githubusercontent.com/1868400/78456724-505fe580-7673-11ea-846f-8a5c32ef9c16.png">


### Viewport < md
<img width="612" alt="Screen Shot 2020-04-04 at 12 51 29 PM" src="https://user-images.githubusercontent.com/1868400/78456691-24dcfb00-7673-11ea-9525-2289d10ee47d.png">



## Summary
- add title
- return location data in `geo.js` endpoint
- add QuadrantMap component
- make page two layout and responsive (1 column when < md viewport)
## Follow up
- Add REACT_APP_MAPBOX_ACCESS_TOKEN to heroku prod environment. I have already added it to staging. I don't have prod heroku access so someone needs to do it here. 