### PR TITLE
feat: ability to trigger a backfill via airtable worker

### DIFF
--- a/scripts/triggerWorkerBackfill.js
+++ b/scripts/triggerWorkerBackfill.js
@@ -12,7 +12,6 @@ const { airbase, UPDATE_BATCH_SIZE } = require("../src/airtable");
     .all();
   const updates = [];
   allResults.forEach(r => {
-    console.log(r.get("Code"));
     const triggerCounter = r.get("Trigger Backfill") || 0;
     updates.push({
       id: r.id,

--- a/scripts/triggerWorkerBackfill.js
+++ b/scripts/triggerWorkerBackfill.js
@@ -1,4 +1,5 @@
 // Triggers a airtable backfill by modifying a watched field for every record
+// https://github.com/crownheightsaid/mutual-aid-app/pull/35
 const _ = require("lodash");
 const { wait } = require("./utils");
 const { airbase, UPDATE_BATCH_SIZE } = require("../src/airtable");

--- a/scripts/triggerWorkerBackfill.js
+++ b/scripts/triggerWorkerBackfill.js
@@ -1,0 +1,29 @@
+// Triggers a airtable backfill by modifying a watched field for every record
+const _ = require("lodash");
+const { wait } = require("./utils");
+const { airbase, UPDATE_BATCH_SIZE } = require("../src/airtable");
+
+/* eslint-disable no-await-in-loop, no-loop-func */
+(async () => {
+  const allResults = await airbase("Requests")
+    .select({
+      fields: ["Trigger Backfill", "Code"]
+    })
+    .all();
+  const updates = [];
+  allResults.forEach(r => {
+    console.log(r.get("Code"));
+    const triggerCounter = r.get("Trigger Backfill") || 0;
+    updates.push({
+      id: r.id,
+      fields: { "Trigger Backfill": triggerCounter + 1 }
+    });
+  });
+  console.log(updates);
+  // unfortunately Airtable only allows 10 records at a time to be updated so batck up the changes
+  for (const batch of _.chunk(updates, UPDATE_BATCH_SIZE)) {
+    await wait(100);
+    const updatedResults = await airbase("Requests").update(batch);
+    console.log(`Updated: ${updatedResults.length}`);
+  }
+})();

--- a/src/workers/airtable-sync/actions/updateMessageContent.js
+++ b/src/workers/airtable-sync/actions/updateMessageContent.js
@@ -24,6 +24,7 @@ module.exports = async function updateMessageContent(record) {
   );
 
   if (existingMessage == null) {
+    console.log(`No existing message for code: ${record.get("Code")}`);
     return;
   }
   const content = existingMessage.text;

--- a/src/workers/airtable-sync/worker.js
+++ b/src/workers/airtable-sync/worker.js
@@ -44,6 +44,7 @@ function startWorker(interval) {
     const statusFieldName = "Status";
     const codeFieldName = "Code";
     const slackIdFieldName = "Delivery slackid";
+    const triggerBackfillFieldName = "Trigger Backfill";
     console.info(`Found ${recordsChanged.length} changes in Requests`);
     for (const record of recordsChanged) {
       //TODO: use this a few more times from different contexts and think about refactoring the api
@@ -57,7 +58,9 @@ function startWorker(interval) {
       if(record.didChange(statusFieldName) || record.didChange(slackIdFieldName)){
         await updateMessageContent(record)
       }
-
+      if(record.didChange(triggerBackfillFieldName)){
+        await updateMessageContent(record)
+      }
     }
   });
 }

--- a/src/workers/airtable-sync/worker.js
+++ b/src/workers/airtable-sync/worker.js
@@ -59,6 +59,7 @@ function startWorker(interval) {
         await updateMessageContent(record)
       }
       if(record.didChange(triggerBackfillFieldName)){
+        console.log("Backfill: " + record.get("Code"));
         await updateMessageContent(record)
       }
     }

--- a/src/workers/airtable-sync/worker.js
+++ b/src/workers/airtable-sync/worker.js
@@ -59,7 +59,6 @@ function startWorker(interval) {
         await updateMessageContent(record)
       }
       if(record.didChange(triggerBackfillFieldName)){
-        console.log("Backfill: " + record.get("Code"));
         await updateMessageContent(record)
       }
     }


### PR DESCRIPTION
This adds a new field `Trigger Backfill` to the Request table. It also adds a script `triggerWorkerBackfill` which increments `Trigger Bacfkill`. The airtable workers can react to this change and perform logic. 

In this case, the logic we perform is changing a Requests posts' Slack message to reflect the `Status` field. This is useful in the case an error occurs during a state change.