### PR TITLE
feat: first name field support in slack app

### DIFF
--- a/src/slackapp/flows/assignToDelivery.js
+++ b/src/slackapp/flows/assignToDelivery.js
@@ -14,9 +14,10 @@ const {
 exports.atdViewSubmission = async payload => {
   try {
     const flowMetadata = JSON.parse(payload.view.private_metadata);
+    const volunteerSlackId = payload.user.id;
     const slackUserResponse = await slackapi.users.info({
       token: process.env.SLACK_BOT_TOKEN,
-      user: payload.user.id
+      user: volunteerSlackId
     });
     const slackUserEmail = slackUserResponse.user.profile.email;
 
@@ -89,7 +90,7 @@ exports.atdViewSubmission = async payload => {
     if (shouldDirectMessage) {
       const dmResponse = await slackapi.conversations.open({
         token: process.env.SLACK_BOT_TOKEN,
-        users: `${delivererSlackId},${volunteer.get("volunteer_slack_id")}`
+        users: `${delivererSlackId},${volunteerSlackId}`
       });
       const messageId = dmResponse.channel.id;
       await slackapi.chat.postMessage({
@@ -109,7 +110,8 @@ exports.atdViewSubmission = async payload => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: `*Phone:*\n>${request.get(
+              text: `*First Name:*\n>${request.get("First Name") ||
+                "N/A"}\n*Phone:*\n>${request.get(
                 "Phone"
               )}\n*Cross Streets:*\n>${request.get(
                 "Cross Street #1"

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -353,6 +353,8 @@ function suggestedTemplate(payload, request) {
   if (quadrant.match(/^NE|SE|SW|NE$/)) {
     quadrant += " Crown Heights";
   }
+  let firstName = request.get("First Name");
+  firstName = firstName ? ` ${firstName}` : "";
 
   const services =
     request.get("What type(s) of support are you seeking?") || [];
@@ -381,7 +383,7 @@ function suggestedTemplate(payload, request) {
   // HACK: use non-breaking space as a delimiter between the status and the rest of the message: \u00A0
   return `${status}\u00A0Hey <!channel> we have a new request ${aidType} ${name} in *${quadrant}*:
 ${fieldRepresentation}
-*Want to volunteer to help our neighbor?* Comment on this thread and <@${slackId}> will follow up with more details.
+*Want to volunteer to help our neighbor${firstName}?* Comment on this thread and <@${slackId}> will follow up with more details.
 _Reminder: Please don’t volunteer for delivery if you have any COVID-19/cold/flu-like symptoms, or have come into contact with someone that’s tested positive._`;
 }
 


### PR DESCRIPTION
Adds First Name from airtable Requests if available. Sensible defaults

Also uses the intake volunteer's slackId from the request, instead of from airtable