### PR TITLE
feat: add bot to channel before interactivity. will fail if not public

### DIFF
--- a/src/slackapi.js
+++ b/src/slackapi.js
@@ -9,7 +9,7 @@ if (!process.env.SLACK_BOT_TOKEN) {
 // An object with the methods listed at https://api.slack.com/methods. Ex:
 // const slackApi = require("..../slackapi.js");
 // ...
-// slackApi.views.publish({token: ...., user_id: ...., view: ....})
+// await slackApi.views.publish({token: ...., user_id: ...., view: ....})
 module.exports = process.env.SLACK_BOT_TOKEN
   ? new WebClient(process.env.SLACK_BOT_TOKEN)
   : null;

--- a/src/slackapp/flows/assignToDelivery.js
+++ b/src/slackapp/flows/assignToDelivery.js
@@ -5,6 +5,7 @@ const {
   messageErrorResponse
 } = require("../views.js");
 const slackapi = require("../../slackapi.js");
+const { addBotToChannel } = require("../lib/channels.js");
 const {
   findVolunteerById,
   updateRequestByCode,
@@ -141,6 +142,7 @@ const atdSubmitCallback = "assign-to-delivery-submit";
 
 exports.atdViewSubmissionCallbackId = atdSubmitCallback;
 exports.atdViewOpen = async payload => {
+  await addBotToChannel(payload.channel.id);
   let codeGuess = "Please enter code manually :/";
   // This means it's a reply and we can try to look for a request Code.
   if (payload.message.thread_ts !== payload.message.ts) {

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -1,6 +1,6 @@
 const { sortBy, isEqual } = require("lodash");
 const slackapi = require("../../slackapi");
-const { findChannelByName } = require("../lib/channels");
+const { findChannelByName, addBotToChannel } = require("../lib/channels");
 const { errorResponse, errorView } = require("../views");
 const {
   findOpenRequests,
@@ -48,6 +48,7 @@ module.exports.register = function register(slackInteractions) {
  * Presents a new modal with a selector for all open requests (that aren't on slack already)
  */
 async function selectRequestForSending(payload) {
+  await addBotToChannel(payload.channel.id);
   const slackUserResponse = await slackapi.users.info({
     token: process.env.SLACK_BOT_TOKEN,
     user: payload.user.id
@@ -131,6 +132,7 @@ async function draftConfirm(payload) {
  */
 async function sendMessage(payload) {
   const context = JSON.parse(payload.view.private_metadata);
+  await addBotToChannel(context.channelId);
 
   // Send the message
   const deliveryMessage = await slackapi.chat.postMessage({

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -48,7 +48,6 @@ module.exports.register = function register(slackInteractions) {
  * Presents a new modal with a selector for all open requests (that aren't on slack already)
  */
 async function selectRequestForSending(payload) {
-  await addBotToChannel(payload.channel.id);
   const slackUserResponse = await slackapi.users.info({
     token: process.env.SLACK_BOT_TOKEN,
     user: payload.user.id

--- a/src/slackapp/lib/channels.js
+++ b/src/slackapp/lib/channels.js
@@ -28,3 +28,21 @@ module.exports.findChannelByName = async name => {
   const bareName = name.replace(/^#/, "");
   return find(await this.allChannels(), c => c.name === bareName);
 };
+
+/**
+ * Finds a channel by its #name. Returns undefined if no element matches
+ */
+module.exports.addBotToChannel = async channelId => {
+  try {
+    const result = await slackapi.conversations.join({
+      token: process.env.SLACK_BOT_TOKEN,
+      channel: channelId
+    });
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return [result, null];
+  } catch (e) {
+    return [null, `Error adding bot to channel: ${channelId}`];
+  }
+};


### PR DESCRIPTION
Fixes #37

 On first request entry (and subsequent actions if used on a dynamic channel) attempt to add the bot the the channel. Fails silently if bot cant be added.