### PR TITLE
Add edit/delete flow to bot messages

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -21,7 +21,7 @@ Finish setting up your slack app
           -   (Name) Edit Post (Callback ID) edit_post
           -   (Name) Post Open Request (Location) Global (Callback ID) select_delivery_needed_request
 1. Go to "Oauth and Permissions"
-     - Add bot scopes: "`commands`", "`users:read`", "`users:read.email`" "`channels:history`" "`channels:write`" "`chat:write`" "`chat:write_public`"
+     - Add bot scopes: "`commands`", "`users:read`", "`users:read.email`" "`channels:history`" "`channels:write`" "`chat:write`" "`chat:write_public`" "`groups:read`"
 1. Go to "Event Subscriptions"
      - Turn on.
      - Add your full `/slack/events` heroku URL to "Request URL"

--- a/SETUP.md
+++ b/SETUP.md
@@ -18,6 +18,7 @@ Finish setting up your slack app
      - Add your full `/slack/interactivity` heroku URL to "Request URL"
      - Add the following under Shortcuts:
           -   (Name) Volunteer Sign Up (Callback ID) volunteer-sign-up
+          -   (Name) Edit Post (Callback ID) edit_post
           -   (Name) Post Open Request (Location) Global (Callback ID) select_delivery_needed_request
 1. Go to "Oauth and Permissions"
      - Add bot scopes: "`commands`", "`users:read`", "`users:read.email`" "`channels:history`" "`channels:write`" "`chat:write`" "`chat:write_public`"

--- a/src/airtable.js
+++ b/src/airtable.js
@@ -73,7 +73,7 @@ exports.findOpenRequests = async () => {
       try {
         parsed = JSON.parse(meta);
       } catch {
-        console.log("Invalid meta %s: $O", r.get("Code"), meta);
+        console.log("Invalid meta %s: %O", r.get("Code"), meta);
       }
       return parsed.slack_ts === undefined;
     };

--- a/src/airtable.js
+++ b/src/airtable.js
@@ -68,8 +68,14 @@ exports.findOpenRequests = async () => {
       })
       .all();
     const notInSlack = r => {
-      const meta = JSON.parse(r.get("Meta"));
-      return meta.slack_ts === undefined;
+      const meta = r.get("Meta");
+      let parsed = {};
+      try {
+        parsed = JSON.parse(meta);
+      } catch {
+        console.log("Invalid meta %s: $O", r.get("Code"), meta);
+      }
+      return parsed.slack_ts === undefined;
     };
     return [requests.filter(notInSlack), null];
   } catch (e) {

--- a/src/slackapp/endpoints/interactivity.js
+++ b/src/slackapp/endpoints/interactivity.js
@@ -6,6 +6,7 @@ const {
 } = require("../flows/assignToDelivery.js");
 
 const createDeliveryRequest = require("../flows/createDeliveryRequest");
+const editPost = require("../flows/editPost");
 
 const slackInteractions = createMessageAdapter(
   process.env.SLACK_SIGNING_SECRET
@@ -38,5 +39,8 @@ slackInteractions.viewSubmission(
 // Delivery Request Post flow
 // ==================================================================
 createDeliveryRequest.register(slackInteractions);
+
+// ==== Edit Post flow ====
+editPost.register(slackInteractions);
 
 module.exports = slackInteractions.requestListener();

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -2,6 +2,7 @@ const { sortBy, isEqual } = require("lodash");
 const slackapi = require("../../slackapi");
 const { findChannelByName, addBotToChannel } = require("../lib/channels");
 const { errorResponse, errorView } = require("../views");
+const guard = require("../lib/guard");
 const {
   findOpenRequests,
   findRequestByCode,
@@ -386,20 +387,4 @@ function suggestedTemplate(payload, request) {
 ${fieldRepresentation}
 *Want to volunteer to help our neighbor${firstName}?* Comment on this thread and <@${slackId}> will follow up with more details.
 _Reminder: Please don’t volunteer for delivery if you have any COVID-19/cold/flu-like symptoms, or have come into contact with someone that’s tested positive._`;
-}
-
-/**
- * Guards a slack callback handler presenting an error response if there is an error.
- */
-function guard(f) {
-  return (payload, ...args) => {
-    return f(payload, ...args).catch(e => {
-      console.error("Got error when processing: %0", e);
-      return slackapi.views.open({
-        token: process.env.SLACK_BOT_TOKEN,
-        trigger_id: payload.trigger_id,
-        view: errorResponse(`Oops got an error: ${e}`)
-      });
-    });
-  };
 }

--- a/src/slackapp/flows/editPost.js
+++ b/src/slackapp/flows/editPost.js
@@ -1,21 +1,35 @@
-const { errorView, successResponse, errorResponse } = require("../views");
+const {
+  errorView,
+  successView,
+  successResponse,
+  errorResponse
+} = require("../views");
 const slackapi = require("../../slackapi");
-const guard = require("../lib/guard")
+const guard = require("../lib/guard");
 
 editPost.id = "edit_post";
 saveEdits.id = "save_post_edit";
+deletePost.id = "delete_post";
 
 /**
  * Adds a message shortcut to allow users to edit bot messages.
  */
 module.exports.register = function register(slackInteractions) {
-  // Prompt uer with editing dialog
+  // Prompt user with editing dialog
   slackInteractions.action(
     {
       type: "message_action",
       callbackId: editPost.id
     },
     guard(editPost)
+  );
+
+  // Handle button that deletes post
+  slackInteractions.action(
+    {
+      actionId: deletePost.id
+    },
+    guard(deletePost)
   );
 
   // Handles actually updating the post
@@ -62,6 +76,26 @@ async function saveEdits(payload) {
   return successResponse("The message was successfully updated");
 }
 
+async function deletePost(payload) {
+  const meta = JSON.parse(payload.view.private_metadata);
+  try {
+    await slackapi.chat.delete({
+      channel: meta.message_channel,
+      ts: meta.message_ts
+    });
+  } catch (e) {
+    console.error("Error deleting message %O %O", meta, e);
+    return slackapi.views.push({
+      trigger_id: payload.trigger_id,
+      view: errorView(`Error deleting message: ${e}`)
+    });
+  }
+  return slackapi.views.update({
+    view_id: payload.view.id,
+    view: successView("Message successfully deleted")
+  });
+}
+
 async function makeEditPostView(payload, message, channel) {
   const meta = {
     message_channel: channel.id,
@@ -98,8 +132,45 @@ async function makeEditPostView(payload, message, channel) {
         },
         label: {
           type: "plain_text",
-          text: "Post",
+          text: "You can edit the post's content:",
           emoji: true
+        }
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Or, if you'd like you can remove the post entirely:"
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Delete Post",
+            emoji: true
+          },
+          action_id: deletePost.id,
+          style: "danger",
+          confirm: {
+            title: {
+              type: "plain_text",
+              text: "Are you sure?"
+            },
+            text: {
+              type: "mrkdwn",
+              text: "The post cannot be un-deleted and any threads will remain."
+            },
+            confirm: {
+              type: "plain_text",
+              text: "Delete Post"
+            },
+            deny: {
+              type: "plain_text",
+              text: "Cancel"
+            },
+            style: "danger"
+          },
+          value: "delete_post"
         }
       }
     ]

--- a/src/slackapp/flows/editPost.js
+++ b/src/slackapp/flows/editPost.js
@@ -56,6 +56,7 @@ async function editPost(payload) {
       "You can only edit messages posted by the bot."
     );
   }
+
   const canEdit = await userCanEditMessage(user, message);
   if (!canEdit) {
     return openError(
@@ -63,6 +64,7 @@ async function editPost(payload) {
       "You aren't permitted to edit this message."
     );
   }
+
   const view = await makeEditPostView(payload, message, channel);
   return slackapi.views.open({
     trigger_id: payload.trigger_id,

--- a/src/slackapp/flows/editPost.js
+++ b/src/slackapp/flows/editPost.js
@@ -1,0 +1,116 @@
+const { errorView, successResponse, errorResponse } = require("../views");
+const slackapi = require("../../slackapi");
+const guard = require("../lib/guard")
+
+editPost.id = "edit_post";
+saveEdits.id = "save_post_edit";
+
+/**
+ * Adds a message shortcut to allow users to edit bot messages.
+ */
+module.exports.register = function register(slackInteractions) {
+  // Prompt uer with editing dialog
+  slackInteractions.action(
+    {
+      type: "message_action",
+      callbackId: editPost.id
+    },
+    guard(editPost)
+  );
+
+  // Handles actually updating the post
+  slackInteractions.viewSubmission(saveEdits.id, guard(saveEdits));
+};
+
+async function editPost(payload) {
+  const { message, channel } = payload;
+  if (!message) {
+    return openError(
+      payload.trigger_id,
+      "This shortcut can only be used on messages."
+    );
+  }
+
+  const botUser = await slackapi.auth.test();
+  if (message.bot_id !== botUser.bot_id) {
+    return openError(
+      payload.trigger_id,
+      "You can only edit messages posted by the bot."
+    );
+  }
+  const view = await makeEditPostView(payload, message, channel);
+  return slackapi.views.open({
+    trigger_id: payload.trigger_id,
+    view
+  });
+}
+
+async function saveEdits(payload) {
+  const meta = JSON.parse(payload.view.private_metadata);
+  const { values } = payload.view.state;
+  const content = values.message.message.value;
+  try {
+    await slackapi.chat.update({
+      channel: meta.message_channel,
+      ts: meta.message_ts,
+      text: content
+    });
+  } catch (e) {
+    console.error("Error updating message %O %O", meta, e);
+    return errorResponse(`Failed to update message: ${e}`);
+  }
+  return successResponse("The message was successfully updated");
+}
+
+async function makeEditPostView(payload, message, channel) {
+  const meta = {
+    message_channel: channel.id,
+    message_ts: message.ts
+  };
+  const editPostBlocks = {
+    type: "modal",
+    callback_id: saveEdits.id,
+    private_metadata: JSON.stringify(meta),
+    title: {
+      type: "plain_text",
+      text: "Edit Post",
+      emoji: true
+    },
+    submit: {
+      type: "plain_text",
+      text: "Save",
+      emoji: true
+    },
+    close: {
+      type: "plain_text",
+      text: "Cancel",
+      emoji: true
+    },
+    blocks: [
+      {
+        type: "input",
+        block_id: "message",
+        element: {
+          type: "plain_text_input",
+          action_id: "message",
+          initial_value: message.text,
+          multiline: true
+        },
+        label: {
+          type: "plain_text",
+          text: "Post",
+          emoji: true
+        }
+      }
+    ]
+  };
+  return editPostBlocks;
+}
+
+function openError(triggerId, message) {
+  console.log(message);
+  return slackapi.views.open({
+    trigger_id: triggerId,
+    view: errorView(message)
+  });
+}

--- a/src/slackapp/lib/channels.js
+++ b/src/slackapp/lib/channels.js
@@ -13,7 +13,10 @@ module.exports.allChannels = async () => {
   let cursor = null;
   const channels = [];
   do {
-    const response = await slackapi.channels.list({ cursor }); // eslint-disable-line
+    const response = await slackapi.conversations.list({
+      types: "public_channel,private_channel",
+      cursor
+    }); // eslint-disable-line
     cursor = response.response_metadata.next_cursor;
     channels.push(...response.channels);
   } while (cursor);
@@ -30,7 +33,7 @@ module.exports.findChannelByName = async name => {
 };
 
 /**
- * Finds a channel by its #name. Returns undefined if no element matches
+ * Adds the current bot to the given channel
  */
 module.exports.addBotToChannel = async channelId => {
   try {
@@ -45,4 +48,23 @@ module.exports.addBotToChannel = async channelId => {
   } catch (e) {
     return [null, `Error adding bot to channel: ${channelId}`];
   }
+};
+
+module.exports.listMembers = async channelId => {
+  let cursor = null;
+  const members = [];
+  try {
+    do {
+      /* eslint no-await-in-loop: off */
+      const response = await slackapi.conversations.members({
+        channel: channelId,
+        cursor
+      });
+      cursor = response.response_metadata.next_cursor;
+      members.push(...response.members);
+    } while (cursor);
+  } catch (e) {
+    return [[], e];
+  }
+  return [members, null];
 };

--- a/src/slackapp/lib/channels.js
+++ b/src/slackapp/lib/channels.js
@@ -50,6 +50,9 @@ module.exports.addBotToChannel = async channelId => {
   }
 };
 
+/**
+ * Returns the user ids of the members of the given channel
+ */
 module.exports.listMembers = async channelId => {
   let cursor = null;
   const members = [];

--- a/src/slackapp/lib/guard.js
+++ b/src/slackapp/lib/guard.js
@@ -1,0 +1,16 @@
+const slackapi = require("../../slackapi");
+const { errorView } = require("../views");
+/**
+ * Guards a slack callback handler presenting an error response if there is an error.
+ */
+module.exports = f => {
+  return (payload, ...args) => {
+    return f(payload, ...args).catch(e => {
+      console.error("Got error when processing: %0", e);
+      return slackapi.views.open({
+        trigger_id: payload.trigger_id,
+        view: errorView(`Oops got an error: ${e}`)
+      });
+    });
+  };
+};

--- a/src/slackapp/views.js
+++ b/src/slackapp/views.js
@@ -14,6 +14,35 @@ const errorView = msg => {
       type: "plain_text",
       text: "Error :("
     },
+    close: {
+      type: "plain_text",
+      text: "Close",
+      emoji: true
+    },
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "plain_text",
+          text: msg
+        }
+      }
+    ]
+  };
+};
+
+const successView = msg => {
+  return {
+    type: "modal",
+    title: {
+      type: "plain_text",
+      text: "Done!"
+    },
+    close: {
+      type: "plain_text",
+      text: "Close",
+      emoji: true
+    },
     blocks: [
       {
         type: "section",
@@ -27,6 +56,7 @@ const errorView = msg => {
 };
 
 exports.errorView = errorView;
+exports.successView = successView;
 
 exports.errorResponse = msg => {
   return {
@@ -38,21 +68,6 @@ exports.errorResponse = msg => {
 exports.successResponse = msg => {
   return {
     response_action: "update",
-    view: {
-      type: "modal",
-      title: {
-        type: "plain_text",
-        text: "Done!"
-      },
-      blocks: [
-        {
-          type: "section",
-          text: {
-            type: "plain_text",
-            text: msg
-          }
-        }
-      ]
-    }
+    view: successView(msg)
   };
 };


### PR DESCRIPTION
This adds a Slack shortcut to edit/delete bot messages. I still want to test this a bit more but it does what it says on the tin.

Right now it restricts editors based on one of two criteria:
 - You can edit a post if you are mentioned in it.
 - You can edit a post if you are a member of #admins or #intake_volunteers. This will necessitate inviting the bot to those channels.

![edit_request](https://user-images.githubusercontent.com/57376/79078005-525d2080-7cd3-11ea-9e91-543aab1568b1.gif)

closes: #41 