### PR TITLE
fix: filter delivery clusters before sending open requests to slack

### DIFF
--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -49,7 +49,8 @@ exports.findRequestByExternalId = async externalId => {
   }
 };
 
-exports.findOpenRequests = async () => {
+// Returns requests that are to be posted in a public requests channel
+exports.findOpenRequestsForSlack = async () => {
   const requestOpenStates = [
     fields.status_options.dispatchStarted,
     fields.status_options.deliveryNeeded
@@ -74,7 +75,13 @@ exports.findOpenRequests = async () => {
       }
       return parsed.slack_ts === undefined;
     };
-    return [requests.filter(notInSlack), null];
+    // Delivery cluster requests are handled separately
+    const notForDrivingCluster = r => {
+      const forDrivingCluster = r.get(fields.forDrivingClusters);
+      return !forDrivingCluster;
+    };
+
+    return [requests.filter(notInSlack).filter(notForDrivingCluster), null];
   } catch (e) {
     return [[], `Error while looking up open requests: ${e}`];
   }

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -5,7 +5,7 @@ const { errorResponse, errorView } = require("~slack/views");
 const guard = require("~slack/guard");
 const { findVolunteerByEmail } = require("~airtable/tables/volunteers");
 const {
-  findOpenRequests,
+  findOpenRequestsForSlack,
   findRequestByCode,
   updateRequestByCode
 } = require("~airtable/tables/requests");
@@ -67,7 +67,7 @@ async function selectRequestForSending(payload) {
     });
     return;
   }
-  let [requests, err] = await findOpenRequests(); // eslint-disable-line
+  let [requests, err] = await findOpenRequestsForSlack(); // eslint-disable-line
   requests = requests.filter(r => {
     const vols = r.get("Intake volunteer") || [];
     return vols.includes(volRecord.getId());


### PR DESCRIPTION
Fixes #53 

We now depend on `For Driving Clusters` field in Requests table