### PR TITLE
Support codes 4-6 chars long

### DIFF
--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -89,9 +89,13 @@ exports.findOpenRequestsForSlack = async () => {
 
 exports.findRequestByCode = async code => {
   try {
+    let issue57Code = code || "------";
+    if (issue57Code.length !== 6) {
+      issue57Code = `--${issue57Code}`;
+    }
     const records = await requestsTable
       .select({
-        filterByFormula: `({${fields.code}} = '${code}')`
+        filterByFormula: `(FIND({${fields.code}}, '${issue57Code}') > 0)`
       })
       .firstPage();
     if (records.length === 0) {
@@ -130,9 +134,13 @@ exports.findRequestByPhone = async phone => {
 // }
 exports.updateRequestByCode = async (code, update) => {
   try {
+    let issue57Code = code || "------";
+    if (issue57Code.length !== 6) {
+      issue57Code = `--${issue57Code}`;
+    }
     const records = await requestsTable
       .select({
-        filterByFormula: `({${fields.code}} = '${code}')`
+        filterByFormula: `(FIND({${fields.code}}, '${issue57Code}') > 0)`
       })
       .firstPage();
     if (records.length === 0) {

--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -88,6 +88,9 @@ exports.findOpenRequestsForSlack = async () => {
 };
 
 exports.findRequestByCode = async code => {
+  if (code && code.length < 4) {
+    return [null, `Request code must be at least 4 characters.`];
+  }
   try {
     const records = await requestsTable
       .select({
@@ -129,6 +132,9 @@ exports.findRequestByPhone = async phone => {
 //   "Meta": {key: "value"}
 // }
 exports.updateRequestByCode = async (code, update) => {
+  if (code && code.length < 4) {
+    return [null, `Request code must be at least 4 characters.`];
+  }
   try {
     const records = await requestsTable
       .select({

--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -89,13 +89,9 @@ exports.findOpenRequestsForSlack = async () => {
 
 exports.findRequestByCode = async code => {
   try {
-    let issue57Code = code || "------";
-    if (issue57Code.length !== 6) {
-      issue57Code = `--${issue57Code}`;
-    }
     const records = await requestsTable
       .select({
-        filterByFormula: `(FIND({${fields.code}}, '${issue57Code}') > 0)`
+        filterByFormula: `(FIND('${code}', {${fields.code}}) > 0)`
       })
       .firstPage();
     if (records.length === 0) {
@@ -134,13 +130,9 @@ exports.findRequestByPhone = async phone => {
 // }
 exports.updateRequestByCode = async (code, update) => {
   try {
-    let issue57Code = code || "------";
-    if (issue57Code.length !== 6) {
-      issue57Code = `--${issue57Code}`;
-    }
     const records = await requestsTable
       .select({
-        filterByFormula: `(FIND({${fields.code}}, '${issue57Code}') > 0)`
+        filterByFormula: `(FIND('${code}', {${fields.code}}) > 0)`
       })
       .firstPage();
     if (records.length === 0) {

--- a/src/slackapp/flows/assignToDelivery.js
+++ b/src/slackapp/flows/assignToDelivery.js
@@ -167,7 +167,7 @@ exports.atdViewOpen = async payload => {
         inclusive: true
       });
       assert(requestMessage.messages.length !== 0, "No messages found.");
-      const capturingRegex = /Code[^\w\d]+(?<code>[\w\d]{4})[^\w\d]*\n/;
+      const capturingRegex = /Code[^\w\d]+(?<code>[\w\d]{4,6})[^\w\d]*\n/;
       const found = requestMessage.messages[0].text.match(capturingRegex);
       if (found.groups.code) {
         codeGuess = found.groups.code;
@@ -220,7 +220,7 @@ exports.atdViewOpen = async payload => {
               type: "plain_text_input",
               action_id: "request_code",
               min_length: 4,
-              max_length: 4,
+              max_length: 6,
               initial_value: codeGuess
             },
             label: {

--- a/src/webapp/components/SaveNeighborhoodDataInput.js
+++ b/src/webapp/components/SaveNeighborhoodDataInput.js
@@ -51,7 +51,7 @@ const SaveNeighborhoodDataInput = ({ neighborhoodData, className }) => {
         <TextField
           id="request_code"
           name="request_code"
-          label="Request code, e.g. V8DL"
+          label="Request code, e.g. V8DLSD"
           type="text"
           margin="normal"
           variant="outlined"


### PR DESCRIPTION
Fixes #57

During Airtable record search, we now search for the entered code in the "Code" string (whatever length it may be). The entered code can then be any length between 4 and 6 characters.  