### PR TITLE
fix: on newPaymentRequest, post failure for not found

### DIFF
--- a/src/lib/strings/locales/en/slackapp.json
+++ b/src/lib/strings/locales/en/slackapp.json
@@ -193,6 +193,10 @@
     },
     "duplicatePost": {
       "message": "*Duplicate Code!*\n:robot_face::robot_face: There is already a reimbursement post for the code {{- code}}. Here is a link to the original post. If there's an issue, please tag @chma-admins!\n{{- threadLink}}"
+    },
+    "requestNotFound": {
+      "message": "*Request Not Found!*\n The request code for a reimbursement didn't exist! If there's an issue, please tag @chma-admins!",
+      "noCode": "PaymentRequest has no code :/"
     }
   }
 }

--- a/src/lib/strings/locales/en/slackapp.json
+++ b/src/lib/strings/locales/en/slackapp.json
@@ -195,7 +195,7 @@
       "message": "*Duplicate Code!*\n:robot_face::robot_face: There is already a reimbursement post for the code {{- code}}. Here is a link to the original post. If there's an issue, please tag @chma-admins!\n{{- threadLink}}"
     },
     "requestNotFound": {
-      "message": "*Request Not Found!*\n The request code for a reimbursement didn't exist! If there's an issue, please tag @chma-admins!",
+      "message": "*Request Not Found!*\n :robot_face::robot_face: The request code for a reimbursement didn't exist! If there's an issue, please tag @chma-admins!",
       "noCode": "PaymentRequest has no code :/"
     }
   }


### PR DESCRIPTION
If the request code provided in the reimbursement form doesn't match, this PR will post to the reimbursement channel that no request was found (with other info from form) and end early