### PR TITLE
feat: two stage external donor posting

### DIFF
--- a/src/lib/airtable/tables/donorPayments.js
+++ b/src/lib/airtable/tables/donorPayments.js
@@ -83,6 +83,7 @@ const fields = (exports.donorPaymentsFields = {
   disputes: "Disputes",
   meta: "Meta",
   lastProcessed: "Last Processed",
-  donorMobile: "DonorMobile"
+  donorMobile: "DonorMobile",
+  posted: "Posted"
 });
 exports.donorPaymentsSensitiveFields = [fields.donorMobile];

--- a/src/lib/airtable/tables/donors.js
+++ b/src/lib/airtable/tables/donors.js
@@ -1,5 +1,16 @@
 const { paymentsAirbase } = require("~airtable/bases");
 
+exports.findDonorById = async id => {
+  if (!id) {
+    return [null, "No id provided for findDonorById"];
+  }
+  try {
+    return [await donorsTable.find(id), null];
+  } catch (e) {
+    return [null, `Errors looking up donor by recordId ${id}: ${e}`];
+  }
+};
+
 // ==================================================================
 // Schema
 // ==================================================================


### PR DESCRIPTION
- When first DonorPayment is created for an external donor, post pending status as slack reply
- When the DonorPayment is moved to `Completed`, post reply with donor basic info and confirmation

Adds new fields `Posted` to DonorPayments 