### PR TITLE
Add feature to show popup for request in URL param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2275,6 +2275,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.53",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.53.tgz",
+      "integrity": "sha512-D2lNbMj6ZcTCbI9yPnlhGW6D/STI2RRTdXFXCKrfWGAFWV27xevNlLNwBuk++mQ5TH9mcJAMI24ej15ztOZXCQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.9.10",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.10.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@googlemaps/google-maps-services-js": "2.4.2",
     "@material-ui/core": "4.9.10",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.53",
     "@material-ui/styles": "4.9.10",
     "@reach/router": "^1.3.3",
     "@slack/events-api": "2.3.2",

--- a/src/lib/strings/locales/en/common.json
+++ b/src/lib/strings/locales/en/common.json
@@ -9,5 +9,14 @@
   "links": {
     "reimbursementForm": "https://airtable.com/shrnf6M0YLn8IwJ71",
     "deliveryGuide": "https://docs.google.com/document/d/1gLQsC3QUylavyzEYXWa7MVuk-H0DOnVtQtFm2fBXDQg/preview"
+  },
+  "webapp": {
+    "deliveryNeeded": {
+      "requestNotFound": {
+        "message": "Request with code {{requestCode}} is not found. This means that the request is no longer in 'Delivery Needed' status.",
+        "redirectLink": "/delivery-needed",
+        "redirectMessage": "See all requests instead."
+      }
+    }
   }
 }

--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -46,7 +46,9 @@ const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
           clusterRadius: 30
         }}
       />
-      <ClusterMapLayers />
+      <ClusterMapLayers
+        geoJsonData={geoJsonData}
+      />
     </BasicMap>
   );
 };

--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Source } from "react-mapbox-gl";
 import { LngLat } from "mapbox-gl";
+import Alert from "@material-ui/lab/Alert";
+import { useTranslation } from "react-i18next";
 import { findBounds } from "../helpers/mapbox-coordinates";
 import {
   CROWN_HEIGHTS_BOUNDS,
@@ -24,32 +26,84 @@ const makeBounds = geoJsonData => {
   return bounds;
 };
 
+const getRequestParam = () => {
+  const searchStr = window.location && window.location.search;
+  return searchStr
+    .slice(1)
+    .split("&")
+    .reduce((acc, token) => {
+      const matches = token.match(/request=(.*)/);
+      return matches ? matches[1] : acc;
+    }, "");
+};
+
+// Alert to show when a request from URL param does not exist
+const RequestNotFoundAlert = ({ requestCode }) => {
+  const { t: str } = useTranslation();
+  return (
+    <Alert severity="warning">
+      {str("webapp.deliveryNeeded.requestNotFound.message", {
+        defaultValue: `Request with code {{requestCode}} is not found. This means that the request is no longer in 'Delivery Needed' status.`,
+        requestCode
+      })}
+{" "}
+      <a
+        href={str("webapp.deliveryNeeded.requestNotFound.redirectLink", {
+          defaultValue: "/delivery-needed"
+        })}
+      >
+        {str("webapp.deliveryNeeded.requestNotFound.redirectMessage", {
+          defaultValue: `See all requests instead.`
+        })}
+      </a>
+    </Alert>
+  );
+};
+
 const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
+  let paramRequest;
+  const requestCode = getRequestParam();
+
+  if (requestCode && geoJsonData && geoJsonData.features) {
+    // find first feature with code match to be passed
+    // into ClusterMapLayers
+    const { features } = geoJsonData;
+    [paramRequest] = features.filter(
+      ({
+        properties: {
+          meta: { Code }
+        }
+      }) => Code === requestCode
+    );
+  }
+
   if (!geoJsonData) {
     return null;
   }
 
   return (
-    <BasicMap
-      center={CROWN_HEIGHTS_CENTER_COORD}
-      bounds={makeBounds(geoJsonData)}
-      containerStyle={containerStyle}
-    >
-      <QuadrantsLayers />
-      <Source
-        id="clusterSource"
-        geoJsonSource={{
-          type: "geojson",
-          data: geoJsonData,
-          cluster: true,
-          clusterMaxZoom: 14,
-          clusterRadius: 30
-        }}
-      />
-      <ClusterMapLayers
-        geoJsonData={geoJsonData}
-      />
-    </BasicMap>
+    <>
+      {!paramRequest && <RequestNotFoundAlert requestCode={requestCode} />}
+
+      <BasicMap
+        center={CROWN_HEIGHTS_CENTER_COORD}
+        bounds={makeBounds(geoJsonData)}
+        containerStyle={containerStyle}
+      >
+        <QuadrantsLayers />
+        <Source
+          id="clusterSource"
+          geoJsonSource={{
+            type: "geojson",
+            data: geoJsonData,
+            cluster: true,
+            clusterMaxZoom: 14,
+            clusterRadius: 30
+          }}
+        />
+        <ClusterMapLayers paramRequest={paramRequest} />
+      </BasicMap>
+    </>
   );
 };
 

--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -61,8 +61,9 @@ const RequestNotFoundAlert = ({ requestCode }) => {
 };
 
 const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
-  let paramRequest;
   const requestCode = getRequestParam();
+
+  let paramRequest;
 
   if (requestCode && geoJsonData && geoJsonData.features) {
     // find first feature with code match to be passed
@@ -81,9 +82,14 @@ const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
     return null;
   }
 
+  // there is a requestCode but the request object does not exist
+  const paramRequestNotFound = requestCode && !paramRequest;
+
   return (
     <>
-      {!paramRequest && <RequestNotFoundAlert requestCode={requestCode} />}
+      {paramRequestNotFound && (
+        <RequestNotFoundAlert requestCode={requestCode} />
+      )}
 
       <BasicMap
         center={CROWN_HEIGHTS_CENTER_COORD}

--- a/src/webapp/components/ClusterMapLayers.jsx
+++ b/src/webapp/components/ClusterMapLayers.jsx
@@ -36,33 +36,14 @@ const makePopupData = (features, lngLat) => {
   });
 };
 
-const getRequestParam = () => {
-  const searchStr = window.location && window.location.search;
-  return searchStr
-    .slice(1)
-    .split("&")
-    .reduce((acc, token) => {
-      const matches = token.match(/request=(.*)/);
-      return matches ? matches[1] : acc;
-    }, "");
-};
-
-const ClusterMapLayers = ({ geoJsonData }) => {
+const ClusterMapLayers = ({ geoJsonData, paramRequest }) => {
   const [popup, setPopup] = useState();
 
   // display popup if request code is present in URL search param
   useEffect(() => {
-    const requestCode = getRequestParam();
-    if (requestCode && geoJsonData && geoJsonData.features) {
-      // find feature, simulate click on latlng on map
-      const currRequest = geoJsonData.features.filter(
-        feat => feat.properties.meta.Code === requestCode
-      )[0];
-      if (currRequest) {
-        setPopup(
-          makePopupData([currRequest], currRequest.geometry.coordinates)
-        );
-      }
+    if (paramRequest) {
+      const { geometry: { coordinates }} = paramRequest;
+      setPopup(makePopupData([paramRequest], coordinates));
     }
   }, []);
 

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -31,9 +31,9 @@ const RequestPopup = ({ requests, closePopup }) => {
     <Popup
       coordinates={requests[0].lngLat}
       offset={{
-        "bottom-left": [12, -38],
-        bottom: [0, -38],
-        "bottom-right": [-12, -38]
+        "bottom-left": [6, -19],
+        bottom: [0, -19],
+        "bottom-right": [-6, -19]
       }}
     >
       {requests.map(({ meta }, i) => (


### PR DESCRIPTION
## Summary

Allow /delivery-needed to receive a request code via URL param and to display popover for corresponding request (if it exists).

e.g. http://localhost:3000/delivery-needed?request=MD4VL2 will open the app with the popover for `MD4VL2` open.

![Screen Shot 2020-05-15 at 4 46 23 PM](https://user-images.githubusercontent.com/1868400/82098472-0129bd80-96d3-11ea-9c19-c979ee41554d.png)

If the request cannot be found, it will display a warning alert with a link to return to the default view. This is to hopefully prevent confusion for folks looking at the map for a claimed delivery/
![Screen Shot 2020-05-15 at 5 36 08 PM](https://user-images.githubusercontent.com/1868400/82098536-21597c80-96d3-11ea-879a-cbdc19bbd979.png)


This can be used for linking the request on the map in the Slack app, making it easier for delivery volunteers to look locations up on the map.

### Limitations
- Opening the popover does not zoom into the location. Default map viewport will always include all open delivery requests
- If there are multiple requests at the same coordinate, it will only show that one request. I decided not to spend time implementing this feature to show all requests at a location for now, but can revisit if needed.
