### PR TITLE
Add alert banner when no requests are found.

### DIFF
--- a/src/lib/strings/locales/en/common.json
+++ b/src/lib/strings/locales/en/common.json
@@ -16,6 +16,9 @@
         "message": "Request with code {{requestCode}} is not found. This means that the request is no longer in 'Delivery Needed' status.",
         "redirectLink": "/delivery-needed",
         "redirectMessage": "See all requests instead."
+      },
+      "noRequests": {
+        "message": "No requests found. Some requests may not have been posted in Slack yet or be marked for driving clusters."
       }
     }
   }

--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -96,7 +96,7 @@ const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
   // there is a requestCode but the request object does not exist
   const paramRequestNotFound = requestCode && !paramRequest;
 
-  const noRequestsFound = geoJsonData.length === 0;
+  const noRequestsFound = geoJsonData.features.length === 0;
 
   return (
     <>

--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -60,6 +60,17 @@ const RequestNotFoundAlert = ({ requestCode }) => {
   );
 };
 
+const NoRequestsAlert = () => {
+  const { t: str } = useTranslation();
+  return (
+    <Alert severity="warning">
+      {str("webapp.deliveryNeeded.noRequests.message", {
+        defaultValue: "No requests found. Some requests may not have been posted in Slack yet or be marked for driving clusters."
+      })}
+    </Alert>
+  )
+}
+
 const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
   const requestCode = getRequestParam();
 
@@ -85,10 +96,16 @@ const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
   // there is a requestCode but the request object does not exist
   const paramRequestNotFound = requestCode && !paramRequest;
 
+  const noRequestsFound = geoJsonData.length === 0;
+
   return (
     <>
       {paramRequestNotFound && (
         <RequestNotFoundAlert requestCode={requestCode} />
+      )}
+
+      {noRequestsFound && (
+        <NoRequestsAlert />
       )}
 
       <BasicMap


### PR DESCRIPTION
# Summary
Display an alert banner on `/delivery-needed` if no requests are found. Delivery requests that haven't been posted to Slack yet or are marked for driving clusters don't show up on this map, so this alert should clear up some confusion. This PR should close issue #76 
![maa-pr-80](https://user-images.githubusercontent.com/1417643/83079562-1f37dc00-a04a-11ea-9842-7aba7771ec8a.png)
