### PR TITLE
Set cursor to pointer when hovering over request map dots

### DIFF
--- a/src/webapp/components/ClusterMapLayers.jsx
+++ b/src/webapp/components/ClusterMapLayers.jsx
@@ -39,6 +39,9 @@ const makePopupData = (features, lngLat) => {
 const ClusterMapLayers = ({ geoJsonData, paramRequest }) => {
   const [popup, setPopup] = useState();
 
+  const setCursorPointer = e => e.target.getCanvas().style.cursor = 'pointer';
+  const setCursorGrab = e => e.target.getCanvas().style.cursor = 'grab';
+
   // display popup if request code is present in URL search param
   useEffect(() => {
     if (paramRequest) {
@@ -77,6 +80,8 @@ const ClusterMapLayers = ({ geoJsonData, paramRequest }) => {
               ]
             }}
             onClick={e => handleClusterOnClick(map, e)}
+            onMouseEnter={setCursorPointer}
+            onMouseLeave={setCursorGrab}
           />
 
           <Layer
@@ -108,8 +113,8 @@ const ClusterMapLayers = ({ geoJsonData, paramRequest }) => {
             onClick={e => {
               setPopup(makePopupData(e.features, e.lngLat));
             }}
-            onMouseEnter={e => e.target.getCanvas().style.cursor = 'pointer'}
-            onMouseLeave={e => e.target.getCanvas().style.cursor = 'grab'}
+            onMouseEnter={setCursorPointer}
+            onMouseLeave={setCursorGrab}
           />
           {popup && (
             <RequestPopup closePopup={() => setPopup()} requests={popup} />

--- a/src/webapp/components/ClusterMapLayers.jsx
+++ b/src/webapp/components/ClusterMapLayers.jsx
@@ -108,6 +108,8 @@ const ClusterMapLayers = ({ geoJsonData, paramRequest }) => {
             onClick={e => {
               setPopup(makePopupData(e.features, e.lngLat));
             }}
+            onMouseEnter={e => e.target.getCanvas().style.cursor = 'pointer'}
+            onMouseLeave={e => e.target.getCanvas().style.cursor = 'grab'}
           />
           {popup && (
             <RequestPopup closePopup={() => setPopup()} requests={popup} />


### PR DESCRIPTION
This PR adds a cursor style of `pointer` when hovering over points on the delivery map. This should make it more apparent that these dots are clickable! When not hovering over a point, the cursor returns to the `grab`, the default for maps.
![Peek 2020-06-05 14-55](https://user-images.githubusercontent.com/1417643/83913526-8e45bc80-a73d-11ea-841a-3684c70c81b6.gif)
This PR closes issue #83