### PR TITLE
Add streets URL to slack app post

### DIFF
--- a/src/lib/strings/locales/en/slackapp.json
+++ b/src/lib/strings/locales/en/slackapp.json
@@ -133,7 +133,9 @@
           "name": "Need"
         },
         "streets": {
-          "name": "Cross Streets"
+          "name": "Cross Streets",
+          "mapUrl": "https://crownheightsma.herokuapp.com/delivery-needed?request={{requestCode}}",
+          "streetsWithMapUrl": "<{{- mapUrl}}|{{streets}}>"
         },
         "language": {
           "name": "Language"

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -367,14 +367,17 @@ function suggestedTemplate(payload, request) {
     .filter(s => s !== undefined)
     .join(" & ");
 
+  const mapUrl = str("slackapp:requestBotPost.post.fields.streets.mapUrl", {
+    defaultValue: `https://crownheightsma.herokuapp.com/delivery-needed?request={{requestCode}}`,
+    requestCode: request.get(requestsFields.code)
+  });
+
   const streetsURL = str(
-    "slackapp:requestBotPost.post.fields.streets.url",
+    "slackapp:requestBotPost.post.fields.streets.streetsWithMapUrl",
     {
-      defaultValue: `<a href="{{endpoint}}?request={{requestCode}}">${streets}</a>`
-    },
-    {
-      endpoint: "https://crownheightsma.herokuapp.com/delivery-needed",
-      requestCode: requestsFields.code
+      defaultValue: `<{{- mapUrl}}|{{streets}}>`,
+      mapUrl,
+      streets
     }
   );
 
@@ -445,7 +448,7 @@ _Reminder: Please don’t volunteer for delivery if you have any COVID-19/cold/f
   firstName
 })}
 ${str("slackapp:requestBotPost.post.message.guide", {
-  defaultValue: `For more information, please see the <{{- guideUrl}}|delivery guide>.`,
+  defaultValue: `For more information, please see the <{{- guideUrl}}|delivery guide>`,
   guideUrl: str("common:links.deliveryGuide")
 })}`;
 }

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -367,6 +367,17 @@ function suggestedTemplate(payload, request) {
     .filter(s => s !== undefined)
     .join(" & ");
 
+  const streetsURL = str(
+    "slackapp:requestBotPost.post.fields.streets.url",
+    {
+      defaultValue: `<a href="{{endpoint}}?request={{requestCode}}">${streets}</a>`
+    },
+    {
+      endpoint: "https://crownheightsma.herokuapp.com/delivery-needed",
+      requestCode: requestsFields.code
+    }
+  );
+
   let quadrant = request.get(requestsFields.neighborhoodArea);
   const { nw, sw, ne, se } = requestsFields.neighborhoodArea_options;
   if ([nw, sw, ne, se].includes(quadrant)) {
@@ -402,7 +413,7 @@ function suggestedTemplate(payload, request) {
       request.get(requestsFields.householdSize) || str("common:notAvailable")
     ],
     [str("slackapp:requestBotPost.post.fields.needs.name"), needs],
-    [str("slackapp:requestBotPost.post.fields.streets.name"), streets],
+    [str("slackapp:requestBotPost.post.fields.streets.name"), streetsURL],
     [
       str("slackapp:requestBotPost.post.fields.language.name"),
       (request.get(requestsFields.languages) || []).join("/")

--- a/src/slackapp/flows/createDeliveryRequest.js
+++ b/src/slackapp/flows/createDeliveryRequest.js
@@ -156,7 +156,10 @@ async function sendMessage(payload) {
   // Send the message
   const deliveryMessage = await slackapi.chat.postMessage({
     channel: context.channelId,
-    text: context.content
+    text: context.content,
+    // We don't want any unfurling of links in the message
+    unfurl_media: false,
+    unfurl_links: false
   });
   if (!deliveryMessage.ok) {
     return errorResponse(


### PR DESCRIPTION
## Summary
Pretty straightforward change to link out to Delivery Needed map from the Slack request post.
It'll link out to something like `https://crownheightsma.herokuapp.com/delivery-needed?request=FDNNBQ`.

Example from my dev Slack app:
![Screen Shot 2020-06-05 at 6 19 27 PM](https://user-images.githubusercontent.com/1868400/83926885-21d8b680-a759-11ea-9bec-a8d9529b01ae.png)

Hover on link:
![Screen Shot 2020-06-05 at 6 19 33 PM](https://user-images.githubusercontent.com/1868400/83926894-29985b00-a759-11ea-8a0e-318b53f5384d.png)


Closes #78 

## Open questions
The map link causes an attachment to appear in the post. Is there a way to tell Slack not to add attachments for the post? I tried looking up ways to do this but couldn't find anything. We can block attachments for any URL domain, but unsure if that's the best way forward. 

Slack post attachment I'm referring to:
![Screen Shot 2020-06-05 at 6 12 51 PM](https://user-images.githubusercontent.com/1868400/83926635-6d3e9500-a758-11ea-8abd-8dbc1d6b0fbd.png)
