### PR TITLE
Mark request complete when reimbursement begins

### DIFF
--- a/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
+++ b/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
@@ -60,7 +60,10 @@ module.exports = async function newPaymentRequest(record) {
     return;
   }
 
-  if (record.get(paymentRequestsFields.type) === paymentRequestsFields.type_options.reimbursement) {
+  if (
+    record.get(paymentRequestsFields.type) ===
+    paymentRequestsFields.type_options.reimbursement
+  ) {
     await markRequestComplete(code);
   }
 

--- a/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
+++ b/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
@@ -12,7 +12,8 @@ const {
 } = require("~airtable/tables/paymentRequests");
 const {
   fields: requestFields,
-  findRequestByCode
+  findRequestByCode,
+  updateRequestByCode
 } = require("~airtable/tables/requests");
 const { str } = require("~strings/i18nextWrappers");
 
@@ -59,6 +60,10 @@ module.exports = async function newPaymentRequest(record) {
     return;
   }
 
+  if (record.get(paymentRequestsFields.type) === paymentRequestsFields.type_options.reimbursement) {
+    await markRequestComplete(code);
+  }
+
   await paymentRequestsTable.update([
     {
       id: record.getId(),
@@ -66,6 +71,12 @@ module.exports = async function newPaymentRequest(record) {
     }
   ]);
 };
+
+async function markRequestComplete(code) {
+  await updateRequestByCode(code, {
+    [requestFields.status]: requestFields.status_options.requestComplete
+  });
+}
 
 async function makeMessageText(reimbursement, request, reimbursementCode) {
   const firstName = reimbursement.get(paymentRequestsFields.firstName);


### PR DESCRIPTION
When someone submits a reimbursement request for a delivery request, the delivery request will be marked "Request Complete".

Testing requires:
- Main Airtable access
- Payments Airtable access
- Slack access
- ngrok running (`npm run local:slack`)
- server running (`npm run local:express`)

Testing process:
1. create a delivery request in "STAGING Intake + Vols: Requests" with the "status" set to anything but "Request Complete", note the code
2. create a reimbursement request in "STAGING P2PMoney: PaymentRequests" with the code from step 1
3. check the row from step 1, "status" should be "Request Complete"

Closes #86 