### PR TITLE
Unlink slack message from record on message delete

### DIFF
--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -1,4 +1,5 @@
 const { merge } = require("lodash");
+const _ = require("lodash");
 const { airbase } = require("~airtable/bases");
 
 const requestNotInSlack = r => {
@@ -193,6 +194,39 @@ exports.updateRequestByCode = async (code, update) => {
     return [null, `Error while processing update: ${e}`];
   }
 };
+
+exports.unlinkSlackMessage = async (slackTs, slackChannel) => {
+  const tsFilter = `"slack_ts":"${slackTs}"`;
+  const channelFilter = `"slack_channel":"${slackChannel}"`;
+  const filter = `AND(SEARCH('${tsFilter}', {${fields.meta}}), SEARCH('${channelFilter}', {${fields.meta}}))`;
+  await requestsTable
+    .select({
+      filterByFormula: filter
+    })
+    .eachPage((records, fetchNextPage) => {
+      records.forEach(async record => {
+        const meta = removeSlackMeta(record.get(fields.meta));
+
+        try {
+          await requestsTable.update([
+            { id: record.id, fields: { [fields.meta]: meta } }
+          ]);
+        } catch (e) {
+          console.error("Error updating Request %O %O", record.id, e);
+        }
+      });
+
+      fetchNextPage();
+    });
+};
+
+const removeSlackMeta = meta =>
+  _.chain(meta)
+    .thru(JSON.parse)
+    .omit("slack_ts")
+    .omit("slack_channel")
+    .thru(JSON.stringify)
+    .value();
 
 // ==================================================================
 // Schema

--- a/src/slackapp/flows/editPost.js
+++ b/src/slackapp/flows/editPost.js
@@ -9,6 +9,7 @@ const guard = require("~slack/guard");
 const { ADMIN_CHANNEL, INTAKE_CHANNEL } = require("~slack/constants");
 const { findChannelByName, listMembers } = require("~slack/channels");
 const { str } = require("~strings/i18nextWrappers");
+const { unlinkSlackMessage } = require("~airtable/tables/requests");
 
 editPost.id = "edit_post";
 saveEdits.id = "save_post_edit";
@@ -109,6 +110,19 @@ async function deletePost(payload) {
       )
     });
   }
+
+  try {
+    await unlinkSlackMessage(meta.message_ts, meta.message_channel);
+  } catch (e) {
+    console.error("Error unlinking message %0 %0 in Airtable", meta, e);
+    return slackapi.views.push({
+      trigger_id: payload.trigger_id,
+      view: errorView(
+        `${str("slackapp:editBotPost.modal.error.deletion")}: ${e}`
+      )
+    });
+  }
+
   return slackapi.views.update({
     view_id: payload.view.id,
     view: successView(str("slackapp:editBotPost.modal.success.deletion"))


### PR DESCRIPTION
This PR adds a new piece of functionality to the `delete_post` Slack interaction. Now, if the post has a corresponding Request record in Airtable, matched by `slack_ts` and `slack_channel` in the `Meta` column, it will remove the Slack metadata. This will allow the Request to be re-posted. Note, however, that this will not apply if you click "Delete message" from the message's context menu. You must instead click the app's "Edit Bot Post" action and pick "delete" from that dialogue box.

Closes #98 