### PR TITLE
Remove unmatched reimbursement requests

### DIFF
--- a/src/lib/airtable/tables/paymentRequests.js
+++ b/src/lib/airtable/tables/paymentRequests.js
@@ -100,7 +100,11 @@ exports.findReimbursablePaymentRequests = async () => {
 };
 
 exports.deletePaymentRequest = async record => {
-  paymentRequestsTable.destroy(record.id)
+  try {
+    await paymentRequestsTable.destroy(record.id)
+  } catch (e) {
+    console.error(`Error while deleting payment request ${e}`);
+  }
 }
 
 // ==================================================================

--- a/src/lib/airtable/tables/paymentRequests.js
+++ b/src/lib/airtable/tables/paymentRequests.js
@@ -99,13 +99,13 @@ exports.findReimbursablePaymentRequests = async () => {
   }
 };
 
-exports.deletePaymentRequest = async record => {
+exports.deletePaymentRequest = async (record) => {
   try {
-    await paymentRequestsTable.destroy(record.id)
+    await paymentRequestsTable.destroy(record.id);
   } catch (e) {
     console.error(`Error while deleting payment request ${e}`);
   }
-}
+};
 
 // ==================================================================
 // Schema

--- a/src/lib/airtable/tables/paymentRequests.js
+++ b/src/lib/airtable/tables/paymentRequests.js
@@ -99,6 +99,10 @@ exports.findReimbursablePaymentRequests = async () => {
   }
 };
 
+exports.deletePaymentRequest = async record => {
+  paymentRequestsTable.destroy(record.id)
+}
+
 // ==================================================================
 // Schema
 // ==================================================================

--- a/src/lib/airtable/tables/paymentRequests.test.js
+++ b/src/lib/airtable/tables/paymentRequests.test.js
@@ -2,21 +2,24 @@ const mockDestroyFn = jest.fn();
 
 jest.mock("~airtable/bases", () => ({
   paymentsAirbase: () => ({
-    destroy: mockDestroyFn
-  })
-}))
+    destroy: mockDestroyFn,
+  }),
+}));
 
-const { deletePaymentRequest, paymentRequestsTableName } = require('./paymentRequests');
 const { Record } = require("airtable");
+const {
+  deletePaymentRequest,
+  paymentRequestsTableName,
+} = require("./paymentRequests");
 
-describe('deletePaymentRequest', () => {
+describe("deletePaymentRequest", () => {
   let paymentRequestRecord;
 
   beforeEach(() => {
-    paymentRequestRecord = new Record(paymentRequestsTableName, 'some-id');
-  })
+    paymentRequestRecord = new Record(paymentRequestsTableName, "some-id");
+  });
 
-  test('sends a delete request to the Payment Request table', async () => {
+  test("sends a delete request to the Payment Request table", async () => {
     await deletePaymentRequest(paymentRequestRecord);
 
     expect(mockDestroyFn).toHaveBeenCalledWith(paymentRequestRecord.id);

--- a/src/lib/airtable/tables/paymentRequests.test.js
+++ b/src/lib/airtable/tables/paymentRequests.test.js
@@ -1,0 +1,24 @@
+const mockDestroyFn = jest.fn();
+
+jest.mock("~airtable/bases", () => ({
+  paymentsAirbase: () => ({
+    destroy: mockDestroyFn
+  })
+}))
+
+const { deletePaymentRequest, paymentRequestsTableName } = require('./paymentRequests');
+const { Record } = require("airtable");
+
+describe('deletePaymentRequest', () => {
+  let paymentRequestRecord;
+
+  beforeEach(() => {
+    paymentRequestRecord = new Record(paymentRequestsTableName, 'some-id');
+  })
+
+  test('sends a delete request to the Payment Request table', async () => {
+    await deletePaymentRequest(paymentRequestRecord);
+
+    expect(mockDestroyFn).toHaveBeenCalledWith(paymentRequestRecord.id);
+  });
+});

--- a/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
+++ b/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
@@ -9,7 +9,7 @@ const {
   paymentRequestsFields,
   paymentRequestsTable,
   findPaymentRequestInSlack,
-  deletePaymentRequest
+  deletePaymentRequest,
 } = require("~airtable/tables/paymentRequests");
 const {
   fields: requestFields,

--- a/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
+++ b/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
@@ -9,6 +9,7 @@ const {
   paymentRequestsFields,
   paymentRequestsTable,
   findPaymentRequestInSlack,
+  deletePaymentRequest
 } = require("~airtable/tables/paymentRequests");
 const {
   fields: requestFields,
@@ -200,6 +201,8 @@ const handleExistingPaymentRequest = async (
 
 const handleNoRequestFound = async (newRecord, code, reimbursementChannel) => {
   console.log(`Handling no request found for code: ${code}`);
+
+  deletePaymentRequest(newRecord);
 
   const slackMessage = newRecord.get(paymentRequestsFields.slackMessage);
   const firstName = newRecord.get(paymentRequestsFields.firstName);


### PR DESCRIPTION
This PR adds a delete method for payment requests, and uses said delete request when a payment request cannot be matched up with a delivery by its code.

Closes #107 