### PR TITLE
Display open delivery days

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6305,10 +6305,9 @@
       "integrity": "sha512-/Uge9DJAT+s+oAcDxtBhyR8+sKjUnZbYmyhbmWjTHNtX7B7oWD8YyYdeXcBRbwSj6hVvj+IQegJam7m7czhbFw=="
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
+      "integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw=="
     },
     "dayjs": {
       "version": "1.8.24",
@@ -10997,6 +10996,12 @@
           "requires": {
             "restore-cursor": "^2.0.0"
           }
+        },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
         },
         "figures": {
           "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2578,6 +2578,71 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.20.2.tgz",
+      "integrity": "sha512-9KOD0fFCTVFsT1EgB8C5qKs1nV7KdIGe0YIANAKeIDWWC0vwkiLXA/8HlrM2+w7YXiRXIeeHh0LxTYQpvaoGgA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.4.6",
+        "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
+          "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.6.tgz",
+      "integrity": "sha512-pVcm8v0HxCEzrtasbC2bdhWM0P5X9o8a/xfBugC97uVVTmhVeGHj+5CdE1JYi/i2K+mCyeq5YqzHLW/gB+K12w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@testing-library/dom": "^7.17.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@tokenizer/token": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
@@ -2659,6 +2724,12 @@
       "requires": {
         "twilio": "^3.33.0"
       }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.9",
@@ -6618,6 +6689,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.6.tgz",
+      "integrity": "sha512-qxFVFR/ymtfamEQT/AsYLe048sitxFCoCHiM+vuOdR3fE94i3so2SCFJxyz/RxV69PZ+9FgToYWOd7eqJqcbYw==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -14142,6 +14219,91 @@
       "requires": {
         "renderkid": "^2.0.1",
         "utila": "~0.4"
+      }
+    },
+    "pretty-format": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^25.5.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "private": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.9.5",
+    "@testing-library/react": "^10.4.6",
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
     "auto-changelog": "^2.0.0",
@@ -103,10 +104,10 @@
     "eslint-plugin-react-hooks": "^2.3.0",
     "i18next-scanner": "2.11.0",
     "ngrok": "3.2.7",
-    "twilio-run": "^2.7.0",
-    "typescript": "^3.9.6",
     "prettier": "^2.0.5",
-    "release-it": "^13.6.4"
+    "release-it": "^13.6.4",
+    "twilio-run": "^2.7.0",
+    "typescript": "^3.9.6"
   },
   "private": true,
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "axios": "0.19.2",
     "axios-hooks": "1.9.0",
     "body-parser": "1.19.0",
+    "date-fns": "^2.14.0",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-basic-auth": "1.2.0",

--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -69,7 +69,7 @@ const makeFeature = async (r) => {
         [forDrivingClusters]: Boolean(r.fields[forDrivingClusters]),
         [householdSize]: r.fields[householdSize],
         slackPermalink: slackPermalink.ok ? slackPermalink.permalink : "",
-        slackTs: metaJSON.hasOwnProperty("slack_ts") ? metaJSON.slack_ts : "",
+        slackTs: metaJSON.slack_ts || "",
       },
     },
   };

--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -69,6 +69,7 @@ const makeFeature = async (r) => {
         [forDrivingClusters]: Boolean(r.fields[forDrivingClusters]),
         [householdSize]: r.fields[householdSize],
         slackPermalink: slackPermalink.ok ? slackPermalink.permalink : "",
+        slackTs: metaJSON.hasOwnProperty("slack_ts") ? metaJSON.slack_ts : "",
       },
     },
   };

--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -1,0 +1,40 @@
+import React from "react";
+import Chip from "@material-ui/core/Chip";
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  recent: {
+    backgroundColor: "green"
+  },
+  moderate: {
+    backgroundColor: "orange"
+  },
+  urgent: {
+    backgroundColor: "red"
+  }
+})
+
+export const DaysOpenChip = props => {
+  const classes = useStyles();
+
+  let chipColor;
+
+  if (props.daysOpen < 3) {
+    chipColor = classes.recent;
+  } else if (props.daysOpen < 5) {
+    chipColor = classes.moderate;
+  } else {
+    chipColor = classes.urgent;
+  }
+
+  return (
+    <Chip
+      label={`open for ${props.daysOpen} days`}
+      color="primary"
+      size="small"
+      classes={{
+        colorPrimary: chipColor
+      }}
+    />
+  );
+}

--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -29,7 +29,7 @@ export const DaysOpenChip = props => {
 
   return (
     <Chip
-      label={`open for ${props.daysOpen} days`}
+      label={`open for ${props.daysOpen} day(s)`}
       color="primary"
       size="small"
       classes={{

--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -1,20 +1,20 @@
 import React from "react";
 import Chip from "@material-ui/core/Chip";
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles({
   recent: {
-    backgroundColor: "green"
+    backgroundColor: "green",
   },
   moderate: {
-    backgroundColor: "orange"
+    backgroundColor: "orange",
   },
   urgent: {
-    backgroundColor: "red"
-  }
-})
+    backgroundColor: "red",
+  },
+});
 
-export const DaysOpenChip = props => {
+const DaysOpenChip = (props) => {
   const classes = useStyles();
 
   let chipColor;
@@ -33,8 +33,10 @@ export const DaysOpenChip = props => {
       color="primary"
       size="small"
       classes={{
-        colorPrimary: chipColor
+        colorPrimary: chipColor,
       }}
     />
   );
-}
+};
+
+export default DaysOpenChip;

--- a/src/webapp/components/DaysOpenChip.test.js
+++ b/src/webapp/components/DaysOpenChip.test.js
@@ -1,37 +1,43 @@
 import React from "react";
-import { render, screen } from '@testing-library/react';
-import { DaysOpenChip } from './DaysOpenChip';
+import { render } from "@testing-library/react";
+import DaysOpenChip from "./DaysOpenChip";
 
-describe('DaysOpenChip', () => {
+describe("DaysOpenChip", () => {
   let container;
 
-  describe('when daysOpen is less than 3', () => {
+  describe("when daysOpen is less than 3", () => {
     beforeEach(() => {
-      container = render(<DaysOpenChip daysOpen={1} />).container
-    })
+      container = render(<DaysOpenChip daysOpen={1} />).container;
+    });
 
-    test('it is has the \"recent\" class', () => {
-      expect(container.querySelector('div > div').className).toContain('recent');
-    })
-  })
+    test('it is has the "recent" class', () => {
+      expect(container.querySelector("div > div").className).toContain(
+        "recent"
+      );
+    });
+  });
 
-  describe('when daysOpen is in the range [3, 5)', () => {
+  describe("when daysOpen is in the range [3, 5)", () => {
     beforeEach(() => {
-      container = render(<DaysOpenChip daysOpen={4} />).container
-    })
+      container = render(<DaysOpenChip daysOpen={4} />).container;
+    });
 
-    test('it has the \"moderate\" class', () => {
-      expect(container.querySelector('div > div').className).toContain('moderate');
-    })
-  })
+    test('it has the "moderate" class', () => {
+      expect(container.querySelector("div > div").className).toContain(
+        "moderate"
+      );
+    });
+  });
 
-  describe('when daysOpen is 5 or more', () => {
+  describe("when daysOpen is 5 or more", () => {
     beforeEach(() => {
-      container = render(<DaysOpenChip daysOpen={6} />).container
-    })
+      container = render(<DaysOpenChip daysOpen={6} />).container;
+    });
 
-    test('it has the \"urgent\" class', () => {
-      expect(container.querySelector('div > div').className).toContain('urgent');
-    })
-  })
-})
+    test('it has the "urgent" class', () => {
+      expect(container.querySelector("div > div").className).toContain(
+        "urgent"
+      );
+    });
+  });
+});

--- a/src/webapp/components/DaysOpenChip.test.js
+++ b/src/webapp/components/DaysOpenChip.test.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from '@testing-library/react';
+import { DaysOpenChip } from './DaysOpenChip';
+
+describe('DaysOpenChip', () => {
+  let container;
+
+  describe('when daysOpen is less than 3', () => {
+    beforeEach(() => {
+      container = render(<DaysOpenChip daysOpen={1} />).container
+    })
+
+    test('it is has the \"recent\" class', () => {
+      expect(container.querySelector('div > div').className).toContain('recent');
+    })
+  })
+
+  describe('when daysOpen is in the range [3, 5)', () => {
+    beforeEach(() => {
+      container = render(<DaysOpenChip daysOpen={4} />).container
+    })
+
+    test('it has the \"moderate\" class', () => {
+      expect(container.querySelector('div > div').className).toContain('moderate');
+    })
+  })
+
+  describe('when daysOpen is 5 or more', () => {
+    beforeEach(() => {
+      container = render(<DaysOpenChip daysOpen={6} />).container
+    })
+
+    test('it has the \"urgent\" class', () => {
+      expect(container.querySelector('div > div').className).toContain('urgent');
+    })
+  })
+})

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -13,11 +13,12 @@ import Chip from "@material-ui/core/Chip";
 import Tooltip from "@material-ui/core/Tooltip";
 import { DaysOpenChip } from "./DaysOpenChip";
 import { differenceInDays, fromUnixTime } from "date-fns";
+import DaysOpenChip from "./DaysOpenChip";
 
-const daysSinceSlackMessage = slackTs => {
-  const datePosted = fromUnixTime(Number(slackTs))
-  return differenceInDays(new Date(), datePosted)
-}
+const daysSinceSlackMessage = (slackTs) => {
+  const datePosted = fromUnixTime(Number(slackTs));
+  return differenceInDays(new Date(), datePosted);
+};
 
 const useStyles = makeStyles((theme) => ({
   divider: {
@@ -110,7 +111,7 @@ const RequestPopup = ({ requests, closePopup }) => {
             )}
           </Box>
 
-          {meta.slackPermalink ?  (
+          {meta.slackPermalink ? (
             <DaysOpenChip daysOpen={daysSinceSlackMessage(meta.slackTs)} />
           ) : (
             <Typography variant="body2" color="error">

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -11,7 +11,6 @@ import GroupIcon from "@material-ui/icons/Group";
 import DriveEtaIcon from "@material-ui/icons/DriveEta";
 import Chip from "@material-ui/core/Chip";
 import Tooltip from "@material-ui/core/Tooltip";
-import { DaysOpenChip } from "./DaysOpenChip";
 import { differenceInDays, fromUnixTime } from "date-fns";
 import DaysOpenChip from "./DaysOpenChip";
 

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -88,7 +88,7 @@ const RequestPopup = ({ requests, closePopup }) => {
               <Chip
                 label={`${meta["Household Size"] || "n/a"}`}
                 icon={<GroupIcon />}
-                color="secondary"
+                color="info"
                 size="small"
               />
             </Tooltip>

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -96,7 +96,7 @@ const RequestPopup = ({ requests, closePopup }) => {
               <Chip
                 label={`${meta["Household Size"] || "n/a"}`}
                 icon={<GroupIcon />}
-                color="info"
+                color="default"
                 size="small"
               />
             </Tooltip>

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -11,6 +11,13 @@ import GroupIcon from "@material-ui/icons/Group";
 import DriveEtaIcon from "@material-ui/icons/DriveEta";
 import Chip from "@material-ui/core/Chip";
 import Tooltip from "@material-ui/core/Tooltip";
+import { DaysOpenChip } from "./DaysOpenChip";
+import { differenceInDays, fromUnixTime } from "date-fns";
+
+const daysSinceSlackMessage = slackTs => {
+  const datePosted = fromUnixTime(Number(slackTs))
+  return differenceInDays(new Date(), datePosted)
+}
 
 const useStyles = makeStyles((theme) => ({
   divider: {
@@ -103,7 +110,9 @@ const RequestPopup = ({ requests, closePopup }) => {
             )}
           </Box>
 
-          {!meta.slackPermalink && (
+          {meta.slackPermalink ?  (
+            <DaysOpenChip daysOpen={daysSinceSlackMessage(meta.slackTs)} />
+          ) : (
             <Typography variant="body2" color="error">
               {str(
                 "webapp:deliveryNeeded.popup.cantFindSlack",


### PR DESCRIPTION
This PR adds a `DaysOpenChip` component. It is colored conditionally based on the number of days:
- 1-2 days: green
- 3-4 days: orange
- 5+ days: red

It is displayed on the `RequestPopup` for delivery requests. The date is based on the Slack message timestamp.

closes #111 