### PR TITLE
UI tweaks to DaysOpenChip and temporarily hide DeliveryTable

### DIFF
--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -14,22 +14,25 @@ const useStyles = makeStyles({
   },
 });
 
-const DaysOpenChip = (props) => {
+const DaysOpenChip = ({ daysOpen }) => {
   const classes = useStyles();
 
   let chipColor;
 
-  if (props.daysOpen < 3) {
+  if (daysOpen < 3) {
     chipColor = classes.recent;
-  } else if (props.daysOpen < 5) {
+  } else if (daysOpen < 5) {
     chipColor = classes.moderate;
   } else {
     chipColor = classes.urgent;
   }
 
+  const label =
+    daysOpen <= 0 ? `open for <1 day` : `open for ${daysOpen} day(s)`;
+
   return (
     <Chip
-      label={`open for ${props.daysOpen} day(s)`}
+      label={label}
       color="primary"
       size="small"
       classes={{

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -108,18 +108,18 @@ const RequestPopup = ({ requests, closePopup }) => {
                 size="small"
               />
             )}
-          </Box>
 
-          {meta.slackPermalink ? (
-            <DaysOpenChip daysOpen={daysSinceSlackMessage(meta.slackTs)} />
-          ) : (
-            <Typography variant="body2" color="error">
-              {str(
-                "webapp:deliveryNeeded.popup.cantFindSlack",
-                `Can't find Slack link, please search for request code in Slack.`
-              )}
-            </Typography>
-          )}
+            {meta.slackPermalink ? (
+              <DaysOpenChip daysOpen={daysSinceSlackMessage(meta.slackTs)} />
+            ) : (
+              <Typography variant="body2" color="error">
+                {str(
+                  "webapp:deliveryNeeded.popup.cantFindSlack",
+                  `Can't find Slack link, please search for request code in Slack.`
+                )}
+              </Typography>
+            )}
+          </Box>
 
           {i !== requests.length - 1 && <Divider className={classes.divider} />}
         </Box>

--- a/src/webapp/pages/DeliveryNeeded.js
+++ b/src/webapp/pages/DeliveryNeeded.js
@@ -106,7 +106,7 @@ export default function DeliveryNeeded() {
         </Grid>
         <Grid item xs={6}>
           <Box>
-           {/*
+            {/*
             Commenting this out for now until https://github.com/crownheightsaid/mutual-aid-app/issues/125
             is done. This is because from a UI standpoint it can be confusing to have two identical data displays
             that aren't connected to one another.
@@ -114,7 +114,7 @@ export default function DeliveryNeeded() {
             Feel free to uncomment for dev work.
             <DeliveryTable
               rows={data.requests.features.map((f) => f.properties.meta)}
-            />*/}
+            /> */}
           </Box>
         </Grid>
       </Grid>

--- a/src/webapp/pages/DeliveryNeeded.js
+++ b/src/webapp/pages/DeliveryNeeded.js
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import sharedStylesFn from "webapp/style/sharedStyles";
 import ClusterMap from "webapp/components/ClusterMap";
 import Grid from "@material-ui/core/Grid";
-import DeliveryTable from "../components/DeliveryTable";
+// import DeliveryTable from "../components/DeliveryTable";
 
 const useStyles = makeStyles((theme) => ({
   ...sharedStylesFn(theme),
@@ -106,9 +106,15 @@ export default function DeliveryNeeded() {
         </Grid>
         <Grid item xs={6}>
           <Box>
+           {/*
+            Commenting this out for now until https://github.com/crownheightsaid/mutual-aid-app/issues/125
+            is done. This is because from a UI standpoint it can be confusing to have two identical data displays
+            that aren't connected to one another.
+
+            Feel free to uncomment for dev work.
             <DeliveryTable
               rows={data.requests.features.map((f) => f.properties.meta)}
-            />
+            />*/}
           </Box>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Summary
- Move DaysOpenChip to chips row 
- Handle requests open <1 day

before 
![Screen Shot 2020-08-03 at 7 35 22 PM](https://user-images.githubusercontent.com/1868400/89237636-b9278200-d5c1-11ea-8246-d0d0a002297a.png)

after
![Screen Shot 2020-08-03 at 7 39 00 PM](https://user-images.githubusercontent.com/1868400/89237652-c47aad80-d5c1-11ea-895d-3f333ef4a452.png)

- Comment out DeliveryTable. This is because upon testing it out in staging, I realized it can be confusing for volunteers to see the identical data sets displayed in two formats without any connection between them. IMO it would be best to not display it until we complete https://github.com/crownheightsaid/mutual-aid-app/issues/125 (which I have on deck). I still wanted to leave the code in master instead of reverting the commit that introduced it for future dev work can happen without having to work off a branch. We still definitely want to use the table and its going to be crucial for the SMS pickup project, just hiding it temporarily for now!

cc: @sandfort @allthesignals 