### PR TITLE
Make Delivery map and table view responsive

### DIFF
--- a/src/webapp/pages/DeliveryNeeded.js
+++ b/src/webapp/pages/DeliveryNeeded.js
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import sharedStylesFn from "webapp/style/sharedStyles";
 import ClusterMap from "webapp/components/ClusterMap";
 import Grid from "@material-ui/core/Grid";
-import DeliveryTable from "../components/DeliveryTable";
+// import DeliveryTable from "../components/DeliveryTable";
 
 const useStyles = makeStyles((theme) => ({
   ...sharedStylesFn(theme),
@@ -59,7 +59,7 @@ export default function DeliveryNeeded() {
       <Grid container spacing={3} direction="row-reverse">
         <Grid item xs={12} md={6}>
           <Box>
-           {/*
+            {/*
             Commenting this out for now until https://github.com/crownheightsaid/mutual-aid-app/issues/125
             is done. This is because from a UI standpoint it can be confusing to have two identical data displays
             that aren't connected to one another.

--- a/src/webapp/pages/DeliveryNeeded.js
+++ b/src/webapp/pages/DeliveryNeeded.js
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import sharedStylesFn from "webapp/style/sharedStyles";
 import ClusterMap from "webapp/components/ClusterMap";
 import Grid from "@material-ui/core/Grid";
-// import DeliveryTable from "../components/DeliveryTable";
+import DeliveryTable from "../components/DeliveryTable";
 
 const useStyles = makeStyles((theme) => ({
   ...sharedStylesFn(theme),
@@ -59,9 +59,17 @@ export default function DeliveryNeeded() {
       <Grid container spacing={3} direction="row-reverse">
         <Grid item xs={12} md={6}>
           <Box>
+           {/*
+            Commenting this out for now until https://github.com/crownheightsaid/mutual-aid-app/issues/125
+            is done. This is because from a UI standpoint it can be confusing to have two identical data displays
+            that aren't connected to one another.
+  
+            Feel free to uncomment for dev work.
+
             <DeliveryTable
               rows={data.requests.features.map((f) => f.properties.meta)}
             />
+          */}
           </Box>
         </Grid>
         <Grid item xs={12} md={6}>
@@ -108,20 +116,6 @@ export default function DeliveryNeeded() {
                 </a>
               </ListItem>
             </List>
-          </Box>
-        </Grid>
-
-        <Grid item xs={6}>
-          <Box>
-            {/*
-            Commenting this out for now until https://github.com/crownheightsaid/mutual-aid-app/issues/125
-            is done. This is because from a UI standpoint it can be confusing to have two identical data displays
-            that aren't connected to one another.
-
-            Feel free to uncomment for dev work.
-            <DeliveryTable
-              rows={data.requests.features.map((f) => f.properties.meta)}
-            /> */}
           </Box>
         </Grid>
       </Grid>

--- a/src/webapp/pages/DeliveryNeeded.js
+++ b/src/webapp/pages/DeliveryNeeded.js
@@ -18,11 +18,9 @@ const useStyles = makeStyles((theme) => ({
     "flex-direction": "row",
     margin: theme.spacing(4),
   },
-  description: {
-    marginTop: theme.spacing(4),
-  },
   mapRoot: {
     marginTop: theme.spacing(4),
+    marginBottom: theme.spacing(4),
   },
 }));
 
@@ -58,8 +56,15 @@ export default function DeliveryNeeded() {
           geoJsonData={data}
         />
       </Box>
-      <Grid container spacing={3}>
-        <Grid item xs={6}>
+      <Grid container spacing={3} direction="row-reverse">
+        <Grid item xs={12} md={6}>
+          <Box>
+            <DeliveryTable
+              rows={data.requests.features.map((f) => f.properties.meta)}
+            />
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={6}>
           <Box className={classes.description}>
             <Typography variant="body1">
               {str("webapp:deliveryNeeded.mapDesc", {
@@ -97,18 +102,12 @@ export default function DeliveryNeeded() {
                 {str("webapp:deliveryNeeded.description.questions", {
                   defaultValue: `Questions or concerns? Please let us know in`,
                 })}
+                <span>&nbsp;</span>
                 <a href={str("webapp:slack.techChannelUrl")}>
                   {str("webapp:slack.techChannel")}
                 </a>
               </ListItem>
             </List>
-          </Box>
-        </Grid>
-        <Grid item xs={6}>
-          <Box>
-            <DeliveryTable
-              rows={data.requests.features.map((f) => f.properties.meta)}
-            />
           </Box>
         </Grid>
       </Grid>


### PR DESCRIPTION
- Give table and informational text full width columns on small screens.

- On small screens, the table appears above the info text.

I fixed a couple other minor styling issues while I was in there:

- Added spacing between text and the link to the #tech channel.

- Cleaned up spacing below the map: info and table are now aligned.

Resolves #129