### PR TITLE
Display all delivery requests by default

### DIFF
--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -31,13 +31,14 @@ const makeBounds = (features) => {
 
 const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
   const requestCode = getRequestParam();
-  const [showDrivingClusters, setShowDrivingClusters] = useState(false);
+  const [showDrivingRequests, setShowDrivingRequests] = useState(true);
+  const [showRegularRequests, setShowRegularRequests] = useState(true);
 
   let paramRequest;
   const { requests, drivingClusterRequests } = geoJsonData;
   const { features: reqFeatures } = requests;
   const { features: clusterFeatures } = drivingClusterRequests;
-  const allRequests = showDrivingClusters
+  const allRequests = showDrivingRequests
     ? [...reqFeatures, ...clusterFeatures]
     : reqFeatures;
 
@@ -67,11 +68,20 @@ const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
       <FormControlLabel
         control={
           <Checkbox
-            checked={showDrivingClusters}
-            onClick={() => setShowDrivingClusters(!showDrivingClusters)}
+            checked={showRegularRequests}
+            onClick={() => setShowRegularRequests(!showRegularRequests)}
           />
         }
-        label="Show driving clusters"
+        label="Regular requests"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={showDrivingRequests}
+            onClick={() => setShowDrivingRequests(!showDrivingRequests)}
+          />
+        }
+        label="Driving cluster requests"
       />
       <BasicMap
         center={CROWN_HEIGHTS_CENTER_COORD}
@@ -99,12 +109,14 @@ const ClusterMap = ({ geoJsonData, containerStyle = {} }) => {
             clusterRadius: 30,
           }}
         />
-        <ClusterMapLayers
-          sourceId="requestsSource"
-          paramRequest={paramRequest}
-          color="orangered"
-        />
-        {showDrivingClusters && (
+        {showRegularRequests && (
+          <ClusterMapLayers
+            sourceId="requestsSource"
+            paramRequest={paramRequest}
+            color="orangered"
+          />
+        )}
+        {showDrivingRequests && (
           <ClusterMapLayers
             sourceId="drivingClusterRequestsSource"
             paramRequest={paramRequest}


### PR DESCRIPTION
- Replaces the single checkbox ("Show Driving Clusters") with two checkboxes: "Driving Cluster Requests" and "Regular requests".
- Both are checked by default.
- Updates some names for the sake of consistency.

Resolves #139

Here's what it looks like with the change:

![demo-map-checkboxes](https://user-images.githubusercontent.com/12530451/90026285-1a67e900-dc85-11ea-8580-0327db04bea7.gif)

I considered stacking the checkboxes vertically, but decided against it since it pushed the map further down the page. Here's what that would look like: 

![map-checkboxes-vertical](https://user-images.githubusercontent.com/12530451/90025336-f952c880-dc83-11ea-9050-6e3d7cc7d928.png)
