### PR TITLE
Test donor payments table

### DIFF
--- a/src/lib/airtable/tables/donorPayments.test.js
+++ b/src/lib/airtable/tables/donorPayments.test.js
@@ -1,0 +1,26 @@
+const mockCreate = jest.fn().mockResolvedValue('value')
+
+jest.mock("~airtable/bases", () => ({
+  paymentsAirbase: () => {
+    return {create: mockCreate}
+  }
+}))
+
+const { createDonorPayment } = require("./donorPayments")
+const { donorPaymentsFields } = require("./donorPaymentsSchema");
+
+const { paymentsAirbase } = require('~airtable/bases')
+
+describe('createDonorPayment', () => {
+  const params ={
+    [donorPaymentsFields.amount]: 'some test amount',
+    [donorPaymentsFields.status]: 'some test status'
+  }
+  
+  test('it creates a donor payment record with the given fields', async () => {
+    const result = await createDonorPayment(params);
+
+    expect(paymentsAirbase().create).toHaveBeenCalledWith([{fields: params}])
+    expect(result).toEqual(['value', null])
+  })
+})

--- a/src/lib/airtable/tables/donorPayments.test.js
+++ b/src/lib/airtable/tables/donorPayments.test.js
@@ -1,4 +1,4 @@
-const mockCreate = jest.fn().mockResolvedValue('value')
+const mockCreate = jest.fn()
 
 jest.mock("~airtable/bases", () => ({
   paymentsAirbase: () => {
@@ -16,11 +16,32 @@ describe('createDonorPayment', () => {
     [donorPaymentsFields.amount]: 'some test amount',
     [donorPaymentsFields.status]: 'some test status'
   }
-  
-  test('it creates a donor payment record with the given fields', async () => {
-    const result = await createDonorPayment(params);
 
-    expect(paymentsAirbase().create).toHaveBeenCalledWith([{fields: params}])
-    expect(result).toEqual(['value', null])
+  describe('on a successful Airtable call', () => {
+
+    beforeEach(() => {
+      mockCreate.mockResolvedValue('value')
+    })
+    
+    test('it creates a donor payment record with the given fields', async () => {
+      const result = await createDonorPayment(params);
+      
+      expect(paymentsAirbase().create).toHaveBeenCalledWith([{fields: params}])
+      expect(result).toEqual(['value', null])
+    })
+  })
+
+  describe('on an unsuccessful Airtable call', () => {
+
+    beforeEach(() => {
+      mockCreate.mockRejectedValue('error')
+    })
+    
+    test('it creates a donor payment record with the given fields', async () => {
+      const result = await createDonorPayment(params);
+      
+      expect(paymentsAirbase().create).toHaveBeenCalledWith([{fields: params}])
+      expect(result).toEqual([null, 'error'])
+    })
   })
 })

--- a/src/lib/airtable/tables/donorPayments.test.js
+++ b/src/lib/airtable/tables/donorPayments.test.js
@@ -1,79 +1,92 @@
-const mockCreate = jest.fn()
-const mockSelect = jest.fn()
+const mockCreate = jest.fn();
+const mockSelect = jest.fn();
 
 jest.mock("~airtable/bases", () => ({
   paymentsAirbase: () => {
     return {
       create: mockCreate,
-      select: mockSelect
-    }
-  }
-}))
+      select: mockSelect,
+    };
+  },
+}));
 
-const { createDonorPayment, findDonorPaymentByCode } = require("./donorPayments")
+const {
+  createDonorPayment,
+  findDonorPaymentByCode,
+} = require("./donorPayments");
 const { donorPaymentsFields } = require("./donorPaymentsSchema");
 
-const { paymentsAirbase } = require('~airtable/bases')
+const { paymentsAirbase } = require("~airtable/bases");
 
-describe('createDonorPayment', () => {
-  const params ={
-    [donorPaymentsFields.amount]: 'some test amount',
-    [donorPaymentsFields.status]: 'some test status'
-  }
+describe("createDonorPayment", () => {
+  const params = {
+    [donorPaymentsFields.amount]: "some test amount",
+    [donorPaymentsFields.status]: "some test status",
+  };
 
-  describe('on a successful Airtable call', () => {
-
+  describe("on a successful Airtable call", () => {
     beforeEach(() => {
-      mockCreate.mockResolvedValue('value')
-    })
-    
-    test('it creates a donor payment record with the given fields', async () => {
+      mockCreate.mockResolvedValue("value");
+    });
+
+    test("it creates a donor payment record with the given fields", async () => {
       const result = await createDonorPayment(params);
-      
-      expect(paymentsAirbase().create).toHaveBeenCalledWith([{fields: params}])
-      expect(result).toEqual(['value', null])
-    })
-  })
 
-  describe('on an unsuccessful Airtable call', () => {
+      expect(paymentsAirbase().create).toHaveBeenCalledWith([
+        { fields: params },
+      ]);
+      expect(result).toEqual(["value", null]);
+    });
+  });
 
+  describe("on an unsuccessful Airtable call", () => {
     beforeEach(() => {
-      mockCreate.mockRejectedValue('error')
-    })
-    
-    test('it creates a donor payment record with the given fields', async () => {
+      mockCreate.mockRejectedValue("error");
+    });
+
+    test("it creates a donor payment record with the given fields", async () => {
       const result = await createDonorPayment(params);
-      
-      expect(paymentsAirbase().create).toHaveBeenCalledWith([{fields: params}])
-      expect(result).toEqual([null, 'error'])
-    })
-  })
-})
+
+      expect(paymentsAirbase().create).toHaveBeenCalledWith([
+        { fields: params },
+      ]);
+      expect(result).toEqual([null, "error"]);
+    });
+  });
+});
 
 describe("findDonorPaymentByCode", () => {
   describe("given a code for an existing donor payment record", () => {
     beforeEach(() => {
-      mockSelect.mockReturnValue({firstPage: () => ['some test record']})
-    })
+      mockSelect.mockReturnValue({ firstPage: () => ["some test record"] });
+    });
 
     it("returns that donor payment record", async () => {
-      const result = await findDonorPaymentByCode('some test code')
+      const result = await findDonorPaymentByCode("some test code");
 
-      expect(mockSelect).toHaveBeenCalledWith({filterByFormula: expect.stringContaining(`{${donorPaymentsFields.code}} = "some test code"`)})
-      expect(result).toEqual(['some test record', null])
-    })
-  })
+      expect(mockSelect).toHaveBeenCalledWith({
+        filterByFormula: expect.stringContaining(
+          `{${donorPaymentsFields.code}} = "some test code"`
+        ),
+      });
+      expect(result).toEqual(["some test record", null]);
+    });
+  });
 
-  describe('given a code that does not correspond to an existing donor payment record', () => {
+  describe("given a code that does not correspond to an existing donor payment record", () => {
     beforeEach(() => {
-      mockSelect.mockReturnValue({firstPage: () => undefined})
-    })
+      mockSelect.mockReturnValue({ firstPage: () => undefined });
+    });
 
-    it('returns an error message', async () => {
-      const result = await findDonorPaymentByCode('some test code')
+    it("returns an error message", async () => {
+      const result = await findDonorPaymentByCode("some test code");
 
-      expect(mockSelect).toHaveBeenCalledWith({filterByFormula: expect.stringContaining(`{${donorPaymentsFields.code}} = "some test code"`)})
-      expect(result).toEqual([null, "Valid payment with that code not found"])
-    })
-  })
-})
+      expect(mockSelect).toHaveBeenCalledWith({
+        filterByFormula: expect.stringContaining(
+          `{${donorPaymentsFields.code}} = "some test code"`
+        ),
+      });
+      expect(result).toEqual([null, "Valid payment with that code not found"]);
+    });
+  });
+});

--- a/src/lib/airtable/tables/donorPayments.test.js
+++ b/src/lib/airtable/tables/donorPayments.test.js
@@ -44,7 +44,7 @@ describe("createDonorPayment", () => {
       mockCreate.mockRejectedValue("error");
     });
 
-    test("it creates a donor payment record with the given fields", async () => {
+    test("it returns an error message", async () => {
       const result = await createDonorPayment(params);
 
       expect(paymentsAirbase().create).toHaveBeenCalledWith([


### PR DESCRIPTION
This PR adds some simple unit tests for the donor payments Airtable functions. It has one positive and one negative test for each of the two functions, although no tests for exceptional behavior. I hope the way I mocked the Airtable library will prove to be a good example for testing these library functions.