### PR TITLE
Add reminder to Neighborhood Finder

### DIFF
--- a/src/lib/strings/locales/en/webapp.json
+++ b/src/lib/strings/locales/en/webapp.json
@@ -22,7 +22,8 @@
     "message": {
       "info": "Enter an address and we will look up cross streets and the neighborhood.",
       "help": "For best results, enter street and town (Ex: 1550 dean st brooklyn)",
-      "privacy": "The address will not be stored or logged :)"
+      "privacy": "The address will not be stored or logged :)",
+      "reminder": "Reminder: the boundaries on this map show a defined delivery area, per our Delivery Area proposal that passed 7/25. CHMA cannot make any deliveries outside of this area, no exceptions."
     },
     "label": {
       "crossStreetFirst": "Cross Street #1",

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -126,12 +126,14 @@ export default function NeighborhoodFinder() {
               )}
             </Typography>
             <Typography className={classes.text} variant="body1">
-              {str(
-                "webapp:zoneFinder.message.reminder",
-                `Reminder: the boundaries on this map show a defined delivery area, 
-                per our Delivery Area proposal that passed 7/25. CHMA cannot make 
-                any deliveries outside of this area, no exceptions.`
-              )}
+              <strong>
+                {str(
+                  "webapp:zoneFinder.message.reminder",
+                  `Reminder: the boundaries on this map show a defined delivery area, 
+                  per our Delivery Area proposal that passed 7/25. CHMA cannot make 
+                  any deliveries outside of this area, no exceptions.`
+                )}
+              </strong>
             </Typography>
           </Box>
         )}

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -125,6 +125,14 @@ export default function NeighborhoodFinder() {
                 "The address will not be stored or logged :)"
               )}
             </Typography>
+            <Typography className={classes.text} variant="body1">
+              {str(
+                "webapp:zoneFinder.message.reminder",
+                `Reminder: the boundaries on this map show a defined delivery area, 
+                per our Delivery Area proposal that passed 7/25. CHMA cannot make 
+                any deliveries outside of this area, no exceptions.`
+              )}
+            </Typography>
           </Box>
         )}
         <form onSubmit={handleSubmit} autoComplete="off">


### PR DESCRIPTION
Adds the reminder text to the json field as well as the same text as the default value in the `NeighborhoodFinder` component. Fixes #146 

[Here it is in staging](https://crownheightsma-staging.herokuapp.com/neighborhood-finder) with a screenshot of Airtable:
![image](https://user-images.githubusercontent.com/10456171/92111288-1af22c00-edba-11ea-9c21-b2af4ec15945.png)
