### PR TITLE
add sms delivery/intake/pickup and sms pod twilio functions

### DIFF
--- a/src/twilio/functions/sms/intake-delivery-txts.js
+++ b/src/twilio/functions/sms/intake-delivery-txts.js
@@ -1,0 +1,99 @@
+exports.handler = function codeSms(context, event, callback) { // eslint-disable-line
+  const Airtable = require("airtable"); // eslint-disable-line
+  Airtable.configure({
+    endpointUrl: "https://api.airtable.com",
+    apiKey: context.AIRTABLE_API_KEY // eslint-disable-line
+  });
+
+  const base = Airtable.base("apppK7mrvMPcwtv6d"); // intake + vols base
+  let code = event.body.requestCode;
+  const deliveryPhone = event.body.deliveryPhone; // eslint-disable-line
+  let deliveryName = event.body.deliveryName; // eslint-disable-line
+  let intakePhone = event.body.intakePhone; // eslint-disable-line
+  let intakeName = event.body.intakeName; // eslint-disable-line
+  let body = JSON.stringify(event.body); // eslint-disable-line
+  let missinginfo = false;
+  let missingintake = false;
+  code = code.toUpperCase().trim();
+
+  console.log("incoming message received");
+  console.log(`delivery phone: ${deliveryPhone}`);
+
+  // below: looks up code in request Airtable, gets all important values about the requesting neighbor
+  base("Requests")
+    .select({
+      view: "Grid view", // from staging base
+      maxRecords: 1,
+      filterByFormula: `({Code} = '${code}')`,
+    })
+    .firstPage(function seekRecords(err, records) {
+      records.forEach(function getRecordInfo(record) {
+        console.log("Retrieved", record.get("Code"));
+        console.log("ID", record.id);
+
+        const phone = record.get("Phone");
+        let firstName = record.get("First Name");
+        if (typeof firstName === "undefined") {
+          firstName = "your neighbor";
+        }
+        const list = record.get("Intake General Notes");
+        if (typeof list === "undefined") {
+          missinginfo = true;
+        }
+        const street1 = record.get("Cross Street #1");
+        if (typeof street1 === "undefined") {
+          missinginfo = true;
+        }
+        const street2 = record.get("Cross Street #2");
+        if (typeof street2 === "undefined") {
+          missinginfo = true;
+        }
+        if (intakePhone === " ") {
+          missingintake = true;
+        }
+
+        if (typeof intakeName === "undefined") {
+          intakeName = "ready to help";
+        }
+
+        if (typeof deliveryName === "undefined") {
+          deliveryName = "a CHMA volunteer";
+        }
+
+        let deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nTheir phone is ${phone}, you will need to get in touch with them about the full address. Their cross streets are ${street1} & ${street2}.\n\n${firstName}'s grocery list is: ${list}\n\nThe intake volunteer for this request is ${intakeName}. Their phone # is ${intakePhone}, and they can help if you have any questions - they'll reach out to you to follow up and make sure the delivery goes well!`;
+
+        if (missinginfo === true) {
+          deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nIt looks like some important info might be missing - please follow up with #intake_volunteers on Slack, or text your intake volunteer ${intakeName} at ${intakePhone} - we'll get it sorted out!`;
+        }
+
+        if (missingintake === true) {
+          deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nIt looks like some important info might be missing - please follow up with #intake_volunteers on Slack - we'll get it sorted out`;
+        }
+
+        // sends SMS out to delivery volunteer
+        const twilioClient = context.getTwilioClient();
+
+        twilioClient.messages
+          .create({
+            to: deliveryPhone,
+            from: "+13474180185", // twilio number here
+            body: deliveryText,
+          })
+          .then(function txtIntake() {
+            twilioClient.messages.create(
+              {
+                to: intakePhone,
+                from: "+13474180185", // twilio number here
+                body: `hey! The request with code ${code} for ${firstName} has been picked up by ${deliveryName}! please remember to check in with them, and make sure the request gets completed - their phone # is ${deliveryPhone}. thnx!`,
+              },
+              function finish() {
+                console.log("2 messages sent");
+                // Callback is placed inside the successful response of the 2nd message
+                callback();
+              }
+            ); // end twilio create message
+          }); // end textIntake
+        //  }); // end checkVolunteer
+      }); // end getRecordInfo
+    }); // end seekRecords
+};

--- a/src/twilio/functions/sms/intake-delivery-txts.js
+++ b/src/twilio/functions/sms/intake-delivery-txts.js
@@ -7,13 +7,11 @@ exports.handler = function codeSms(context, event, callback) { // eslint-disable
 
   const base = Airtable.base("apppK7mrvMPcwtv6d"); // intake + vols base
   let code = event.body.requestCode;
-  const deliveryPhone = event.body.deliveryPhone; // eslint-disable-line
-  let deliveryName = event.body.deliveryName; // eslint-disable-line
-  let intakePhone = event.body.intakePhone; // eslint-disable-line
-  let intakeName = event.body.intakeName; // eslint-disable-line
+  const { deliveryPhone, intakePhone } = event.body;
+  let { deliveryName, intakeName } = event.body;
   let body = JSON.stringify(event.body); // eslint-disable-line
-  let missinginfo = false;
-  let missingintake = false;
+  let missingInfo = false;
+  let missingIntake = false;
   code = code.toUpperCase().trim();
 
   console.log("incoming message received");
@@ -38,18 +36,18 @@ exports.handler = function codeSms(context, event, callback) { // eslint-disable
         }
         const list = record.get("Intake General Notes");
         if (typeof list === "undefined") {
-          missinginfo = true;
+          missingInfo = true;
         }
         const street1 = record.get("Cross Street #1");
         if (typeof street1 === "undefined") {
-          missinginfo = true;
+          missingInfo = true;
         }
         const street2 = record.get("Cross Street #2");
         if (typeof street2 === "undefined") {
-          missinginfo = true;
+          missingInfo = true;
         }
         if (intakePhone === " ") {
-          missingintake = true;
+          missingIntake = true;
         }
 
         if (typeof intakeName === "undefined") {
@@ -62,11 +60,11 @@ exports.handler = function codeSms(context, event, callback) { // eslint-disable
 
         let deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nTheir phone is ${phone}, you will need to get in touch with them about the full address. Their cross streets are ${street1} & ${street2}.\n\n${firstName}'s grocery list is: ${list}\n\nThe intake volunteer for this request is ${intakeName}. Their phone # is ${intakePhone}, and they can help if you have any questions - they'll reach out to you to follow up and make sure the delivery goes well!`;
 
-        if (missinginfo === true) {
+        if (missingInfo) {
           deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nIt looks like some important info might be missing - please follow up with #intake_volunteers on Slack, or text your intake volunteer ${intakeName} at ${intakePhone} - we'll get it sorted out!`;
         }
 
-        if (missingintake === true) {
+        if (missingIntake) {
           deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nIt looks like some important info might be missing - please follow up with #intake_volunteers on Slack - we'll get it sorted out`;
         }
 

--- a/src/twilio/functions/sms/pod-verify.js
+++ b/src/twilio/functions/sms/pod-verify.js
@@ -1,0 +1,90 @@
+// SMS bot that lets pod members in CHMA create their own "intake" codes in Airtable
+// without needing to log into Airtable base; allows for delivery + reimbursement to
+// the same neighbors repeatedly
+
+exports.handler = function incomingSms(context, event, callback) {
+  const twiml = new Twilio.twiml.MessagingResponse(); // eslint-disable-line
+  const phone = event.From;
+  const podpass = event.Body;
+  const twilioSid = event.SmsSid; // SMS unique ID
+
+  var Airtable = require('airtable'); // eslint-disable-line
+  Airtable.configure({
+    endpointUrl: "https://api.airtable.com",
+    apiKey: context.AIRTABLE_API_KEY // eslint-disable-line
+  });
+
+  const checkvolbase = Airtable.base("appqIAsILK5TBU5QG"); // pod list base
+  const requestsbase = Airtable.base("apppK7mrvMPcwtv6d"); // request base
+
+  let name = "";
+  let last = "";
+  let volrecord = "";
+
+  if (podpass === "pod") {
+    twiml.message(
+      `hello from crown heights mutual aid! what are you requesting a reimbursement code for, for your pod?`
+    );
+    callback(null, twiml);
+  } else {
+    checkvolbase("Pod Requesters")
+      .select({
+        maxRecords: 1,
+        filterByFormula: `({Phone} = '${phone}')`,
+      })
+      .firstPage(function checkPhone(err, records) {
+        if (err) {
+          console.error(err);
+          return;
+        }
+        if (records.length === 0) {
+          console.log("no one in the base with that number");
+          twiml.message(
+            `hmm, it doesn't look like you're signed up to create requests this way. please talk to the intake working group, on slack at wg_intake!`
+          );
+          callback(null, twiml);
+        } else {
+          records.forEach(function passRequest(record) { // eslint-disable-line
+            console.log("phone number checks out!");
+            name = record.get("First Name");
+            last = record.get("Last Name");
+            volrecord = record.get("Vol Table Record");
+            createRecord();
+          });
+        }
+      });
+  }
+
+  function createRecord() {
+    console.log("creating record");
+    requestsbase("Requests").create(
+      {
+        "Intake General Notes": event.Body,
+        Phone: phone,
+        "Twilio Call Sid": twilioSid,
+        "Text or Voice?": "text",
+        "Neighborhood MA-NYC": "Crown Heights",
+        Status: "Delivery Assigned",
+        Message: "this is a request for a pod",
+        "First Name": name,
+        "Intake volunteer": [volrecord],
+        "Delivery volunteer": `${name} ${last}`,
+        "Pod?": "pod",
+      },
+      function responseTxt(err, record) {
+        if (err) {
+          console.error(err);
+          return;
+        }
+        const requestcode = record.getId(); // Airtable id
+        console.log(requestcode);
+        const shortcode = requestcode.substr(-6).toUpperCase();
+        console.log(shortcode);
+        twiml.message(
+          `thank you for checking on your pod, ${name}! you can use the code ${shortcode} to fill out this CHMA reimbursement form: https://airtable.com/shrnf6M0YLn8IwJ71`
+        );
+        callback(null, twiml);
+      }
+    );
+  } // end of createRecord
+}; // end of exports.handler

--- a/src/twilio/functions/sms/test-delivery.js
+++ b/src/twilio/functions/sms/test-delivery.js
@@ -1,0 +1,102 @@
+// this endpoint version receives delivery/intake name + phone numbers from the React web app
+// used for testing; connects to staging base
+
+exports.handler = function codeSms(context, event, callback) { // eslint-disable-line
+  const Airtable = require("airtable"); // eslint-disable-line
+  Airtable.configure({
+    endpointUrl: "https://api.airtable.com",
+    apiKey: context.AIRTABLE_API_KEY // eslint-disable-line
+  });
+
+  const base = Airtable.base("apppPfEXed7SRcKmB"); // staging base
+  let code = event.body.requestCode;
+  const deliveryPhone = event.body.deliveryPhone; // eslint-disable-line
+  let deliveryName = event.body.deliveryName; // eslint-disable-line
+  let intakePhone = event.body.intakePhone; // eslint-disable-line
+  let intakeName = event.body.intakeName; // eslint-disable-line
+  let body = JSON.stringify(event.body); // eslint-disable-line
+  let missinginfo = false;
+  let missingintake = false;
+  code = code.toUpperCase().trim();
+
+  console.log("incoming message received");
+  console.log(`delivery phone: ${deliveryPhone}`);
+
+  // below: looks up code in request Airtable, gets all important values about the requesting neighbor
+  base("Requests")
+    .select({
+      view: "Grid view", // from staging base
+      maxRecords: 1,
+      filterByFormula: `({Code} = '${code}')`,
+    })
+    .firstPage(function seekRecords(err, records) {
+      records.forEach(function getRecordInfo(record) {
+        console.log("Retrieved", record.get("Code"));
+        console.log("ID", record.id);
+
+        const phone = record.get("Phone");
+        let firstName = record.get("First Name");
+        if (typeof firstName === "undefined") {
+          firstName = "your neighbor";
+        }
+        const list = record.get("Intake General Notes");
+        if (typeof list === "undefined") {
+          missinginfo = true;
+        }
+        const street1 = record.get("Cross Street #1");
+        if (typeof street1 === "undefined") {
+          missinginfo = true;
+        }
+        const street2 = record.get("Cross Street #2");
+        if (typeof street2 === "undefined") {
+          missinginfo = true;
+        }
+        if (intakePhone === " ") {
+          missingintake = true;
+        }
+
+        if (typeof intakeName === "undefined") {
+          intakeName = "ready to help";
+        }
+
+        if (typeof deliveryName === "undefined") {
+          deliveryName = "a CHMA volunteer";
+        }
+
+        let deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nTheir phone is ${phone}, you will need to get in touch with them about the full address. Their cross streets are ${street1} & ${street2}.\n\n${firstName}'s grocery list is: ${list}\n\nThe intake volunteer for this request is ${intakeName}. Their phone # is ${intakePhone}, and they can help if you have any questions - they'll reach out to you to follow up and make sure the delivery goes well!`;
+
+        if (missinginfo === true) {
+          deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nIt looks like some important info might be missing - please follow up with #intake_volunteers on Slack, or text your intake volunteer ${intakeName} at ${intakePhone} - we'll get it sorted out!`;
+        }
+
+        if (missingintake === true) {
+          deliveryText = `Thanks for taking on this delivery for ${firstName}!\nCODE = ${code}.\n\nIt looks like some important info might be missing - please follow up with #intake_volunteers on Slack - we'll get it sorted out`;
+        }
+
+        // sends SMS out to delivery volunteer
+        const twilioClient = context.getTwilioClient();
+
+        twilioClient.messages
+          .create({
+            to: deliveryPhone,
+            from: "+13474180185", // twilio number here
+            body: deliveryText,
+          })
+          .then(function txtIntake() {
+            twilioClient.messages.create(
+              {
+                to: intakePhone,
+                from: "+13474180185", // twilio number here
+                body: `hey! The request with code ${code} for ${firstName} has been picked up by ${deliveryName}! please remember to check in with them, and make sure the request gets completed - their phone # is ${deliveryPhone}. thnx!`,
+              },
+              function finish() {
+                console.log("2 messages sent");
+                // Callback is placed inside the successful response of the 2nd message
+                callback();
+              }
+            ); // end twilio create message
+          }); // end textIntake
+        //  }); // end checkVolunteer
+      }); // end getRecordInfo
+    }); // end seekRecords
+};


### PR DESCRIPTION
additions to src/twilio/functions/sms

these functions are already deployed to Twilio serverless environment:

https://mutual-aid-4526-dev.twil.io/sms/pod-verify
(SMS bot that allows pod members to generate Airtable "intake" codes, in order to make repeated deliveries to the same neighbors and get reimbursed via CHMA system)

https://mutual-aid-4526-dev.twil.io/sms/test-delivery
(staging endpoint, for claiming deliveries via SMS)

https://mutual-aid-4526-dev.twil.io/sms/intake-delivery-txts
(prod endpoint, for claiming deliveries and communication between intake/delivery vols, via SMS)