### PR TITLE
Use 'Date Changed to Delivery Needed' field to calculate days a request has been open

### DIFF
--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -41,7 +41,6 @@ const { TWILIO_SMS_DELIVERY_ENDPOINT } = process.env;
 const makeFeature = async (r) => {
   let metaJSON = {};
   let slackPermalink = {};
-  let timestamp;
 
   const location = await fetchCoordFromCrossStreets(
     `
@@ -68,7 +67,7 @@ const makeFeature = async (r) => {
 
   try {
     const channel = metaJSON.slack_channel;
-    timestamp = metaJSON.slack_ts;
+    const timestamp = metaJSON.slack_ts;
     slackPermalink = await slackapi.chat.getPermalink({
       channel,
       message_ts: timestamp,
@@ -100,7 +99,6 @@ const makeFeature = async (r) => {
         [intakeNotes]: r.fields[intakeNotes],
         need,
         slackPermalink: slackPermalink.ok ? slackPermalink.permalink : "",
-        timestamp,
         dateChangedToDeliveryNeeded: r.fields[dateChangedToDeliveryNeeded],
       },
     },

--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -33,6 +33,7 @@ const {
   timeSensitivity,
   intakeNotes,
   supportType,
+  dateChangedToDeliveryNeeded,
 } = fields;
 
 const { TWILIO_SMS_DELIVERY_ENDPOINT } = process.env;
@@ -100,7 +101,7 @@ const makeFeature = async (r) => {
         need,
         slackPermalink: slackPermalink.ok ? slackPermalink.permalink : "",
         timestamp,
-        slackTs: metaJSON.slack_ts || "",
+        dateChangedToDeliveryNeeded: r.fields[dateChangedToDeliveryNeeded],
       },
     },
   };

--- a/src/lib/airtable/tables/requestsSchema.js
+++ b/src/lib/airtable/tables/requestsSchema.js
@@ -97,6 +97,7 @@ const fields = (exports.fields = {
   neighborhood: "Neighborhood MA-NYC",
   householdSize: "Household Size",
   forDrivingClusters: "For Driving Clusters",
+  dateChangedToDeliveryNeeded: "Date Changed to Delivery Needed",
 });
 exports.SENSITIVE_FIELDS = [
   fields.phone,

--- a/src/lib/strings/locales/en/webapp.json
+++ b/src/lib/strings/locales/en/webapp.json
@@ -73,7 +73,10 @@
     },
     "table": {
       "headers": {
-        "daysOpen": "Days open",
+        "daysOpen": {
+          "header": "Days open",
+          "tooltip": "Number of days since a request has been in \"Delivery Needed\" status. \nIf it says \"n/a\", the information is not available for some reason and you should reach out to #tech_support on Slack"
+        },
         "timeSensitivity": "Time Sensitivity",
         "neighbor": "Neighbor",
         "need": "Need",

--- a/src/lib/strings/locales/en/webapp.json
+++ b/src/lib/strings/locales/en/webapp.json
@@ -61,7 +61,9 @@
     "popup": {
       "slackLink": "See details on Slack",
       "requestCode": "Request code:",
-      "cantFindSlack": "Can't find Slack link, please search for request code in Slack."
+      "cantFindSlack": "Can't find Slack link, please search for request code in Slack.",
+      "daysOpenNotAvailable": "This information is not available for some reason. Please reach out to #tech_support on Slack",
+      "claimDelivery": "Claim delivery"
     },
     "noRequests": {
       "message": "No requests found. Some requests may not have been posted in Slack yet or be marked for driving clusters."
@@ -73,10 +75,7 @@
     },
     "table": {
       "headers": {
-        "daysOpen": {
-          "header": "Days open",
-          "tooltip": "Number of days since a request has been in \"Delivery Needed\" status. \nIf it says \"n/a\", the information is not available for some reason and you should reach out to #tech_support on Slack"
-        },
+        "daysOpen": "Days open",
         "timeSensitivity": "Time Sensitivity",
         "neighbor": "Neighbor",
         "need": "Need",

--- a/src/webapp/components/ClusterMap.js
+++ b/src/webapp/components/ClusterMap.js
@@ -12,7 +12,7 @@ import BasicMap from "./BasicMap";
 import { QuadrantsLayers } from "./QuadrantMap";
 import ClusterMapLayers from "./ClusterMapLayers";
 import { RequestNotFoundAlert, NoRequestsAlert } from "./MapAlerts";
-import { daysSinceSlackMessage } from "../helpers/time";
+import { getDaysSinceIsoTimestamp } from "../helpers/time";
 import getParam from "../helpers/utils";
 
 const makeBounds = (features) => {
@@ -31,7 +31,9 @@ const makeBounds = (features) => {
 
 const addDaysOpen = (feature) => {
   const styles = getUrgencyStyles(
-    daysSinceSlackMessage(feature.properties.meta.timestamp)
+    getDaysSinceIsoTimestamp(
+      feature.properties.meta.dateChangedToDeliveryNeeded
+    )
   );
   const markerColor = styles.backgroundColor;
   return {

--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -1,9 +1,16 @@
 import React from "react";
 import Chip from "@material-ui/core/Chip";
 import { makeStyles } from "@material-ui/core/styles";
+import Tooltip from "@material-ui/core/Tooltip";
+import { useTranslation } from "react-i18next";
 import { getUrgencyLevel, urgencyStyles } from "../helpers/map-urgency";
 
-const useStyles = makeStyles(urgencyStyles);
+const useStyles = makeStyles(() => ({
+  ...urgencyStyles,
+  tooltip: {
+    fontSize: "0.8rem",
+  },
+}));
 
 function getTime(daysOpen) {
   if (daysOpen < 0) {
@@ -16,8 +23,23 @@ function getTime(daysOpen) {
   return `${daysOpen} day(s)`;
 }
 
+const getOptionalTooltipTitle = (daysOpen, translateFunction) => {
+  if (daysOpen < 0) {
+    return translateFunction(
+      "webapp:deliveryNeeded.popup.daysOpenNotAvailable",
+      {
+        defaultValue:
+          "This information is not available for some reason. Please reach out to #tech_support on Slack",
+      }
+    );
+  }
+
+  return null;
+};
+
 const DaysOpenChip = ({ daysOpen, timeOnly }) => {
   const classes = useStyles();
+  const { t: str } = useTranslation();
 
   const urgencyLevel = getUrgencyLevel(daysOpen);
   const chipColor = classes[urgencyLevel];
@@ -25,7 +47,9 @@ const DaysOpenChip = ({ daysOpen, timeOnly }) => {
   const time = getTime(daysOpen);
   const label = timeOnly ? time : `open for ${time}`;
 
-  return (
+  const optionalTooltip = getOptionalTooltipTitle(daysOpen, str);
+
+  const chip = (
     <Chip
       label={label}
       color="primary"
@@ -35,6 +59,20 @@ const DaysOpenChip = ({ daysOpen, timeOnly }) => {
       }}
     />
   );
+
+  if (optionalTooltip) {
+    return (
+      <Tooltip
+        title={optionalTooltip}
+        classes={{ tooltip: classes.tooltip }}
+        arrow
+      >
+        {chip}
+      </Tooltip>
+    );
+  }
+
+  return chip;
 };
 
 export default DaysOpenChip;

--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles(urgencyStyles);
 
 function getTime(daysOpen) {
   if (daysOpen < 0) {
-    return "invalid";
+    return "n/a";
   }
   if (daysOpen === 0) {
     return "<1 day";

--- a/src/webapp/components/DaysOpenChip.js
+++ b/src/webapp/components/DaysOpenChip.js
@@ -5,13 +5,24 @@ import { getUrgencyLevel, urgencyStyles } from "../helpers/map-urgency";
 
 const useStyles = makeStyles(urgencyStyles);
 
+function getTime(daysOpen) {
+  if (daysOpen < 0) {
+    return "invalid";
+  }
+  if (daysOpen === 0) {
+    return "<1 day";
+  }
+
+  return `${daysOpen} day(s)`;
+}
+
 const DaysOpenChip = ({ daysOpen, timeOnly }) => {
   const classes = useStyles();
 
   const urgencyLevel = getUrgencyLevel(daysOpen);
   const chipColor = classes[urgencyLevel];
 
-  const time = daysOpen <= 0 ? `<1 day` : `${daysOpen} day(s)`;
+  const time = getTime(daysOpen);
   const label = timeOnly ? time : `open for ${time}`;
 
   return (

--- a/src/webapp/components/DaysOpenChip.test.js
+++ b/src/webapp/components/DaysOpenChip.test.js
@@ -5,6 +5,18 @@ import DaysOpenChip from "./DaysOpenChip";
 describe("DaysOpenChip", () => {
   let container;
 
+  describe("when daysOpen is less than 0 (invalid)", () => {
+    beforeEach(() => {
+      container = render(<DaysOpenChip daysOpen={-1} />).container;
+    });
+
+    test('it has the "invalid" class', () => {
+      expect(container.querySelector("div > div").className).toContain(
+        "invalid"
+      );
+    });
+  });
+
   describe("when daysOpen is less than 3", () => {
     beforeEach(() => {
       container = render(<DaysOpenChip daysOpen={1} />).container;

--- a/src/webapp/components/DeliveryTable.js
+++ b/src/webapp/components/DeliveryTable.js
@@ -5,7 +5,6 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import Tooltip from "@material-ui/core/Tooltip";
 import Paper from "@material-ui/core/Paper";
 import { makeStyles } from "@material-ui/core/styles";
 import { useTranslation } from "react-i18next";
@@ -17,28 +16,18 @@ const useStyles = makeStyles(() => ({
   container: {
     maxHeight: "90vh",
   },
-  headerTooltip: {
-    fontSize: "0.8rem",
-  },
 }));
 
 const TableHeadRow = () => {
-  const classes = useStyles();
   const { t: str } = useTranslation();
   return (
     <TableRow>
       <TableCell />
-      <Tooltip
-        title={str("webapp:deliveryNeeded.table.headers.daysOpen.tooltip")}
-        classes={{ tooltip: classes.headerTooltip }}
-        arrow
-      >
-        <TableCell>
-          {str("webapp:deliveryNeeded.table.headers.daysOpen.header", {
-            defaultValue: "Days open",
-          })}
-        </TableCell>
-      </Tooltip>
+      <TableCell>
+        {str("webapp:deliveryNeeded.table.headers.daysOpen", {
+          defaultValue: "Days open",
+        })}
+      </TableCell>
       <TableCell>
         {str("webapp:deliveryNeeded.table.headers.timeSensitivity", {
           defaultValue: "Time Sensitivity",

--- a/src/webapp/components/DeliveryTable.js
+++ b/src/webapp/components/DeliveryTable.js
@@ -5,28 +5,40 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import Tooltip from "@material-ui/core/Tooltip";
 import Paper from "@material-ui/core/Paper";
 import { makeStyles } from "@material-ui/core/styles";
 import { useTranslation } from "react-i18next";
 import ClusterMapContext from "../context/ClusterMapContext";
 import DeliveryTableRow from "./DeliveryTableRow";
+import { getDaysSinceIsoTimestamp } from "../helpers/time";
 
 const useStyles = makeStyles(() => ({
   container: {
     maxHeight: "90vh",
   },
+  headerTooltip: {
+    fontSize: "0.8rem",
+  },
 }));
 
 const TableHeadRow = () => {
+  const classes = useStyles();
   const { t: str } = useTranslation();
   return (
     <TableRow>
       <TableCell />
-      <TableCell>
-        {str("webapp:deliveryNeeded.table.headers.daysOpen", {
-          defaultValue: "Days open",
-        })}
-      </TableCell>
+      <Tooltip
+        title={str("webapp:deliveryNeeded.table.headers.daysOpen.tooltip")}
+        classes={{ tooltip: classes.headerTooltip }}
+        arrow
+      >
+        <TableCell>
+          {str("webapp:deliveryNeeded.table.headers.daysOpen.header", {
+            defaultValue: "Days open",
+          })}
+        </TableCell>
+      </Tooltip>
       <TableCell>
         {str("webapp:deliveryNeeded.table.headers.timeSensitivity", {
           defaultValue: "Time Sensitivity",
@@ -65,17 +77,19 @@ const DeliveryTable = ({ rows }) => {
     }
   });
 
-  // sort happens in-place
-  rows.sort((rowA, rowB) => rowA.timestamp - rowB.timestamp);
-
   const formattedRows = rows.map((row) => {
     const isFocused = row.Code === focusedRequestId;
+    const daysOpen = getDaysSinceIsoTimestamp(row.dateChangedToDeliveryNeeded);
 
     return {
       ...row,
+      daysOpen,
       isFocused,
     };
   });
+
+  // sort happens in-place (descending order)
+  formattedRows.sort((rowA, rowB) => rowB.daysOpen - rowA.daysOpen);
 
   return (
     <TableContainer

--- a/src/webapp/components/DeliveryTableRow.js
+++ b/src/webapp/components/DeliveryTableRow.js
@@ -12,7 +12,7 @@ import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 import { makeStyles } from "@material-ui/core/styles";
 import { useTranslation } from "react-i18next";
 import DaysOpenChip from "./DaysOpenChip";
-import { daysSinceSlackMessage } from "../helpers/time";
+import { getDaysSinceIsoTimestamp } from "../helpers/time";
 import ClusterMapContext from "../context/ClusterMapContext";
 import HouseholdSizeChip from "./HouseholdSizeChip";
 import DrivingClusterChip from "./DrivingClusterChip";
@@ -76,7 +76,7 @@ const DeliveryTableRow = (props) => {
         <TableCell>
           <DaysOpenChip
             timeOnly
-            daysOpen={daysSinceSlackMessage(row.slackTs)}
+            daysOpen={getDaysSinceIsoTimestamp(row.dateChangedToDeliveryNeeded)}
           />
         </TableCell>
         <TableCell>{row["Time Sensitivity"] || "Not Stated"}</TableCell>

--- a/src/webapp/components/DeliveryTableRow.js
+++ b/src/webapp/components/DeliveryTableRow.js
@@ -12,7 +12,6 @@ import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 import { makeStyles } from "@material-ui/core/styles";
 import { useTranslation } from "react-i18next";
 import DaysOpenChip from "./DaysOpenChip";
-import { getDaysSinceIsoTimestamp } from "../helpers/time";
 import ClusterMapContext from "../context/ClusterMapContext";
 import HouseholdSizeChip from "./HouseholdSizeChip";
 import DrivingClusterChip from "./DrivingClusterChip";
@@ -74,10 +73,7 @@ const DeliveryTableRow = (props) => {
           </Tooltip>
         </TableCell>
         <TableCell>
-          <DaysOpenChip
-            timeOnly
-            daysOpen={getDaysSinceIsoTimestamp(row.dateChangedToDeliveryNeeded)}
-          />
+          <DaysOpenChip timeOnly daysOpen={row.daysOpen} />
         </TableCell>
         <TableCell>{row["Time Sensitivity"] || "Not Stated"}</TableCell>
         <TableCell>

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -11,7 +11,7 @@ import sharedStylesFn from "webapp/style/sharedStyles";
 import DaysOpenChip from "./DaysOpenChip";
 import HouseholdSizeChip from "./HouseholdSizeChip";
 import DrivingClusterChip from "./DrivingClusterChip";
-import { daysSinceSlackMessage } from "../helpers/time";
+import { getDaysSinceIsoTimestamp } from "../helpers/time";
 import ClusterMapContext from "../context/ClusterMapContext";
 import ClaimDeliveryButton from "./ClaimDeliveryButton";
 
@@ -101,7 +101,11 @@ const RequestPopup = ({ requests, closePopup }) => {
             {meta["For Driving Clusters"] && <DrivingClusterChip />}
 
             {meta.slackPermalink ? (
-              <DaysOpenChip daysOpen={daysSinceSlackMessage(meta.slackTs)} />
+              <DaysOpenChip
+                daysOpen={getDaysSinceIsoTimestamp(
+                  meta.dateChangedToDeliveryNeeded
+                )}
+              />
             ) : (
               <Typography variant="body2" color="error">
                 {str(

--- a/src/webapp/helpers/map-urgency.js
+++ b/src/webapp/helpers/map-urgency.js
@@ -4,7 +4,7 @@
  */
 export const urgencyStyles = {
   invalid: {
-    backgroundColor: "black",
+    backgroundColor: "grey",
   },
   recent: {
     backgroundColor: "green",

--- a/src/webapp/helpers/map-urgency.js
+++ b/src/webapp/helpers/map-urgency.js
@@ -3,6 +3,9 @@
  * usable by Material UI.
  */
 export const urgencyStyles = {
+  invalid: {
+    backgroundColor: "black",
+  },
   recent: {
     backgroundColor: "green",
   },
@@ -21,6 +24,9 @@ export const urgencyStyles = {
  * @param {number} daysOpen
  */
 export const getUrgencyLevel = (daysOpen) => {
+  if (daysOpen < 0) {
+    return "invalid";
+  }
   if (daysOpen < 3) {
     return "recent";
   }

--- a/src/webapp/helpers/map-urgency.test.js
+++ b/src/webapp/helpers/map-urgency.test.js
@@ -1,6 +1,14 @@
 const { getUrgencyStyles } = require("./map-urgency");
 
 describe("Urgency styles", () => {
+  test("it should return the styles for 'n/a' requests", () => {
+    const daysOpen = -1;
+    const styles = getUrgencyStyles(daysOpen);
+    expect(styles).toStrictEqual({
+      backgroundColor: "grey",
+    });
+  });
+
   test("it should return the styles for 'recent' requests", () => {
     const daysOpen = 1;
     const styles = getUrgencyStyles(daysOpen);

--- a/src/webapp/helpers/time.js
+++ b/src/webapp/helpers/time.js
@@ -1,8 +1,15 @@
-import { differenceInDays, fromUnixTime } from "date-fns";
+import { differenceInDays, parseISO } from "date-fns";
 
-const daysSinceSlackMessage = (slackTs) => {
-  const datePosted = fromUnixTime(Number(slackTs));
+/**
+ * @param {string} isoTimestamp - ISO timestamp, eg "2020-10-09T18:38:28.000Z"
+ * @returns {number} - difference in days since provided ISO timestamp
+ */
+const getDaysSinceIsoTimestamp = (isoTimestamp) => {
+  if (!isoTimestamp) {
+    return -1;
+  }
+  const datePosted = parseISO(isoTimestamp);
   return differenceInDays(new Date(), datePosted);
 };
 
-export { daysSinceSlackMessage };
+export { getDaysSinceIsoTimestamp };

--- a/src/webapp/helpers/time.js
+++ b/src/webapp/helpers/time.js
@@ -5,7 +5,7 @@ import { differenceInDays, parseISO } from "date-fns";
  * @returns {number} - difference in days since provided ISO timestamp
  */
 const getDaysSinceIsoTimestamp = (isoTimestamp) => {
-  if (!isoTimestamp) {
+  if (!isoTimestamp || typeof isoTimestamp !== "string") {
     return -1;
   }
   const datePosted = parseISO(isoTimestamp);

--- a/src/webapp/helpers/time.test.js
+++ b/src/webapp/helpers/time.test.js
@@ -1,0 +1,23 @@
+const { getDaysSinceIsoTimestamp } = require("./time");
+
+describe("helpers/time.js", () => {
+  describe("getDaysSinceIsoTimestamp", () => {
+    test("should return -1 for invalid input", () => {
+      expect(getDaysSinceIsoTimestamp(undefined)).toStrictEqual(-1);
+      expect(getDaysSinceIsoTimestamp(null)).toStrictEqual(-1);
+      expect(getDaysSinceIsoTimestamp(false)).toStrictEqual(-1);
+      expect(getDaysSinceIsoTimestamp(0)).toStrictEqual(-1);
+      expect(getDaysSinceIsoTimestamp(12345)).toStrictEqual(-1);
+    });
+
+    test("should return 0 for the same day", () => {
+      const actual = getDaysSinceIsoTimestamp(new Date().toISOString());
+      expect(actual).toStrictEqual(0);
+    });
+
+    test("should return a positive integer for valid input older than today", () => {
+      const actual = getDaysSinceIsoTimestamp("2020-04-20");
+      expect(actual).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes issue #158 

This is my first PR, so let me know if anything is amiss! 

If this looks good, a `hacktoberfest-accepted` label on the PR would be much appreciated 😁 

**Reviewers**
- Let me know if the new `invalid` time label is poorly thought-out or implemented.
- Is there a test suite to run?

## Changes
- Added `dateChangedToDeliveryNeeded` field to requests' fields
- Added `invalid` color state to handle rows that are missing the field (time function return `-1`)
- Removed `slackTs` field (no longer needed? duplicate of `timestamp`?)
## Testing
- ran `npm run lint` and `npm run test`
- Populated the `Date Changed to Delivery Needed` field for a few rows and saw it render properly in the table


**Screenshot:**
![image](https://user-images.githubusercontent.com/7434338/96282386-a7daf880-0fa8-11eb-8032-3192383eed01.png)

