### PR TITLE
Ignore JetBrains IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ ngrok.yml
 # ignore macOS .DS_Store
 **/.DS_Store
 
+# IntelliJ / JetBrains IDEs
+.idea*


### PR DESCRIPTION
For all of us PHPStorm/Webstorm/IntelliJ/etc users :)

For example, while setting up the project and putting up my first PR, all these files were generated:
```
	new file:   .idea/.gitignore
	new file:   .idea/codeStyles/Project.xml
	new file:   .idea/codeStyles/codeStyleConfig.xml
	new file:   .idea/inspectionProfiles/Project_Default.xml
	new file:   .idea/misc.xml
	new file:   .idea/modules.xml
	new file:   .idea/mutual-aid-app.iml
	new file:   .idea/vcs.xml
```

I imagine we don't want these committed to the repo.