### PR TITLE
Stop filtering requests based on their presence in Slack

### DIFF
--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -99,7 +99,7 @@ const makeFeature = async (r) => {
         [timeSensitivity]: r.fields[timeSensitivity],
         [intakeNotes]: r.fields[intakeNotes],
         need,
-        slackPermalink: slackPermalink.permalink ?? "",
+        slackPermalink: slackPermalink.permalink || "",
         dateChangedToDeliveryNeeded: r.fields[dateChangedToDeliveryNeeded],
       },
     },

--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -1,3 +1,4 @@
+const _ = require("lodash");
 const axios = require("axios");
 const {
   findDeliveryNeededRequests,
@@ -98,7 +99,7 @@ const makeFeature = async (r) => {
         [timeSensitivity]: r.fields[timeSensitivity],
         [intakeNotes]: r.fields[intakeNotes],
         need,
-        slackPermalink: slackPermalink.ok ? slackPermalink.permalink : "",
+        slackPermalink: slackPermalink.permalink ?? "",
         dateChangedToDeliveryNeeded: r.fields[dateChangedToDeliveryNeeded],
       },
     },
@@ -114,13 +115,10 @@ exports.deliveryNeededRequestHandler = async (req, res) => {
       .send({ message: `Error fetching requests: ${requestErr}` });
   }
 
-  const regularRequestsPromises = requestObj
-    .filter((r) => !r.fields[forDrivingClusters])
-    .map(makeFeature);
-
-  const clusterRequestsPromises = requestObj
-    .filter((r) => Boolean(r.fields[forDrivingClusters]))
-    .map(makeFeature);
+  const [clusterRequestsPromises, regularRequestsPromises] = _.partition(
+    requestObj,
+    (r) => r.fields[forDrivingClusters]
+  ).map((promises) => promises.map(makeFeature));
 
   const regularRequests = await Promise.all(regularRequestsPromises);
   const clusterRequests = await Promise.all(clusterRequestsPromises);

--- a/src/lib/airtable/tables/__tests__/requests.test.js
+++ b/src/lib/airtable/tables/__tests__/requests.test.js
@@ -154,20 +154,23 @@ describe("findRequestByExternalId", () => {
 });
 
 describe("findDeliveryNeededRequests", () => {
-  describe("when all requests have been posted in Slack", () => {
-    let result;
-    let record;
+  let result;
+  let records;
 
-    beforeAll(async () => {
-      record = buildRequestRecord({ id: "abc", postedInSlack: true });
+  afterEach(() => {
+    mockSelectFn.mockClear();
+  });
 
-      mockSelectFn.mockReturnValue({ all: () => [record] });
+  describe("when the request succeeds", () => {
+    beforeEach(async () => {
+      records = [
+        buildRequestRecord({ id: "abc", postedInSlack: true }),
+        buildRequestRecord({ id: "def", postedInSlack: false }),
+      ];
+
+      mockSelectFn.mockReturnValue({ all: () => [records] });
 
       result = await findDeliveryNeededRequests();
-    });
-
-    afterEach(() => {
-      mockSelectFn.mockClear();
     });
 
     test("it sends a request with a query", () => {
@@ -176,36 +179,25 @@ describe("findDeliveryNeededRequests", () => {
       });
     });
 
-    test("it returns the results", () => {
-      expect(result[0]).toEqual([record]);
+    test("it returns results successfully", () => {
+      expect(result[0]).toEqual([records]);
       expect(result[1]).toEqual(null);
     });
   });
 
-  describe("when there are requests not posted in Slack", () => {
-    let result;
-    let record;
+  describe("when the request fails", () => {
+    const ERROR_MESSAGE = "ruh roh, an error!";
 
-    beforeAll(async () => {
-      record = buildRequestRecord({ id: 1, postedInSlack: true });
-      const notInSlackRecord = buildRequestRecord({
-        id: 2,
-        postedInSlack: false,
+    beforeEach(async () => {
+      mockSelectFn.mockImplementation(() => {
+        throw new Error(ERROR_MESSAGE);
       });
-
-      mockSelectFn.mockReturnValue({ all: () => [record, notInSlackRecord] });
-
       result = await findDeliveryNeededRequests();
     });
 
-    afterAll(() => {
-      mockSelectFn.mockClear();
-    });
-
-    test("it only returns records posted in Slack", () => {
-      expect(result[0]).toHaveLength(1);
-      expect(result[0]).toEqual([record]);
-      expect(result[1]).toEqual(null);
+    test("it returns an error", () => {
+      expect(result[0]).toEqual([]);
+      expect(result[1].includes(ERROR_MESSAGE)).toBe(true);
     });
   });
 });

--- a/src/lib/airtable/tables/__tests__/requests.test.js
+++ b/src/lib/airtable/tables/__tests__/requests.test.js
@@ -175,7 +175,7 @@ describe("findDeliveryNeededRequests", () => {
 
     test("it sends a request with a query", () => {
       expect(mockSelectFn).toHaveBeenCalledWith({
-        filterByFormula: `OR({${fields.status}} = '${fields.status_options.dispatchStarted}', {${fields.status}} = '${fields.status_options.deliveryNeeded}')`,
+        filterByFormula: `OR({${fields.status}} = '${fields.status_options.deliveryNeeded}')`,
       });
     });
 

--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -69,7 +69,7 @@ exports.findRequestByExternalId = async (externalId) => {
 
 /** Finds all requests in an open state (ie 'delivery needed' status) in Airtable */
 exports.findDeliveryNeededRequests = async () => {
-  const filterByFormula = `OR(${fields.status} = '${fields.status_options.deliveryNeeded}')`;
+  const filterByFormula = `OR({${fields.status}} = '${fields.status_options.deliveryNeeded}')`;
   try {
     const requests = await table
       .select({

--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -67,7 +67,7 @@ exports.findRequestByExternalId = async (externalId) => {
   }
 };
 
-// Find open requests that area already in Slack
+/** Finds all requests in an open state (ie needing delivery) in Airtable */
 exports.findDeliveryNeededRequests = async () => {
   const requestOpenStates = [
     fields.status_options.dispatchStarted,
@@ -84,7 +84,7 @@ exports.findDeliveryNeededRequests = async () => {
       })
       .all();
 
-    return [requests.filter((r) => !requestNotInSlack(r)), null];
+    return [requests, null];
   } catch (e) {
     return [[], `Error while looking up open requests: ${e}`];
   }

--- a/src/lib/airtable/tables/requests.js
+++ b/src/lib/airtable/tables/requests.js
@@ -67,20 +67,13 @@ exports.findRequestByExternalId = async (externalId) => {
   }
 };
 
-/** Finds all requests in an open state (ie needing delivery) in Airtable */
+/** Finds all requests in an open state (ie 'delivery needed' status) in Airtable */
 exports.findDeliveryNeededRequests = async () => {
-  const requestOpenStates = [
-    fields.status_options.dispatchStarted,
-    fields.status_options.deliveryNeeded,
-  ];
-  const statusConstraints = requestOpenStates.map(
-    (s) => `{${fields.status}} = '${s}'`
-  );
-  const formula = `OR(${statusConstraints.join(", ")})`;
+  const filterByFormula = `OR(${fields.status} = '${fields.status_options.deliveryNeeded}')`;
   try {
     const requests = await table
       .select({
-        filterByFormula: formula,
+        filterByFormula,
       })
       .all();
 

--- a/src/webapp/components/DeliveryTable.js
+++ b/src/webapp/components/DeliveryTable.js
@@ -92,7 +92,7 @@ const DeliveryTable = ({ rows }) => {
         </TableHead>
         <TableBody>
           {formattedRows.map((row) => (
-            <DeliveryTableRow row={row} key={row.code} />
+            <DeliveryTableRow row={row} key={row.Code} />
           ))}
         </TableBody>
       </Table>

--- a/src/webapp/components/DeliveryTableRow.js
+++ b/src/webapp/components/DeliveryTableRow.js
@@ -84,14 +84,18 @@ const DeliveryTableRow = (props) => {
           </Box>
         </TableCell>
         <TableCell component="th" scope="row">
-          <Link
-            href={row.slackPermalink}
-            target="_blank"
-            underline="always"
-            rel="noopener noreferrer"
-          >
-            {row.Code}
-          </Link>
+          {row.slackPermalink ? (
+            <Link
+              href={row.slackPermalink}
+              target="_blank"
+              underline="always"
+              rel="noopener noreferrer"
+            >
+              {row.Code}
+            </Link>
+          ) : (
+            <span>{row.Code}</span>
+          )}
         </TableCell>
         <TableCell>{`${row["Cross Street #1"]} and ${row["Cross Street #2"]}`}</TableCell>
       </TableRow>

--- a/src/webapp/components/RequestPopup.js
+++ b/src/webapp/components/RequestPopup.js
@@ -90,8 +90,8 @@ const RequestPopup = ({ requests, closePopup }) => {
           <Typography variant="body2">
             {str("webapp:deliveryNeeded.popup.requestCode", {
               defaultValue: `Request code:`,
-              // eslint-disable-next-line react/jsx-one-expression-per-line
-            })}{" "}
+            })}
+            &nbsp;
             {meta.Code}
           </Typography>
 


### PR DESCRIPTION
Issue #157 

### Changes
- Removed `notInSlack` filter
- Added checks for `slackPermalink` in presentational component (when needed)
- A few minor fixes; sorry, couldn't help myself 😅 

### Testing
- Modified `requests.js` unit tests
- Checked table rows with and without the link
- Checked map popup with and without link
- `npm run lint` and `npm run test` ✔

Screenshot:
![image](https://user-images.githubusercontent.com/7434338/97047270-b1cf9f00-1546-11eb-9a5c-ee77b50594bf.png)
