### PR TITLE
Test volunteers lib

### DIFF
--- a/scripts/backfillVolunteersToRelevantChannels.js
+++ b/scripts/backfillVolunteersToRelevantChannels.js
@@ -7,7 +7,7 @@ const { VOLUNTEER_INTERESTS_TO_SLACK_CHANNELS } = require("~slack/constants");
 const {
   volunteersFields,
   volunteersTable,
-} = require("~airtable/tables/volunteers");
+} = require("~airtable/tables/volunteersSchema");
 const { wait } = require("./utils");
 
 /* eslint-disable no-await-in-loop, no-loop-func, guard-for-in, no-continue */

--- a/src/api/delivery-needed/index.js
+++ b/src/api/delivery-needed/index.js
@@ -6,9 +6,9 @@ const {
 } = require("~airtable/tables/requests");
 const {
   findVolunteerByPhone,
-  volunteersFields,
   findVolunteerById,
 } = require("~airtable/tables/volunteers");
+const { volunteersFields } = require("~airtable/tables/volunteersSchema");
 const { fields } = require("~airtable/tables/requestsSchema");
 const { fetchCoordFromCrossStreets } = require("./fetchCoordFromCrossStreets");
 const slackapi = require("~slack/webApi");

--- a/src/lib/airtable/tables/__tests__/volunteers.test.js
+++ b/src/lib/airtable/tables/__tests__/volunteers.test.js
@@ -11,7 +11,7 @@ const {
 } = require("../volunteers.js");
 
 describe("findVolunteerByEmail", () => {
-  describe("when the email is not found", () => {
+  describe("when the email is NOT found", () => {
     const email = "notreal@example.com";
     let result;
     
@@ -25,6 +25,38 @@ describe("findVolunteerByEmail", () => {
     test("it returns an error message", () => {
       expect(result[0]).toBeNull();
       expect(result[1]).toEqual(expect.stringContaining(`No volunteer signed up with email ${email}`));
+    });
+  });
+
+  describe("when the email IS found", () => {
+    let result;
+
+    beforeEach(async () => {
+      mockSelectFn.mockReturnValue({firstPage: () => ["a volunteer"]});
+
+      result = await findVolunteerByEmail("real@example.com");
+    });
+
+    test("it returns the volunteer record", () => {
+      expect(result[0]).toEqual("a volunteer");
+      expect(result[1]).toBeNull();
+    });
+  });
+
+  describe("when there is an error", () => {
+    const email = "error@example.com";
+    const errorMessage = "some error";
+    let result;
+
+    beforeEach(async () => {
+      mockSelectFn.mockReturnValue({firstPage: jest.fn().mockRejectedValue(errorMessage)});
+
+      result = await findVolunteerByEmail(email);
+    });
+
+    test("it returns the error message", () => {
+      expect(result[0]).toBeNull();
+      expect(result[1]).toEqual(`Errors looking up volunteer by email ${email}: ${errorMessage}`);
     });
   });
 });

--- a/src/lib/airtable/tables/__tests__/volunteers.test.js
+++ b/src/lib/airtable/tables/__tests__/volunteers.test.js
@@ -1,13 +1,16 @@
 const mockSelectFn = jest.fn();
+const mockFindFn = jest.fn();
 
 jest.mock("~airtable/bases", () => ({
   airbase: () => ({
     select: mockSelectFn,
+    find: mockFindFn,
   }),
 }));
 
 const {
-  findVolunteerByEmail
+  findVolunteerByEmail,
+  findVolunteerById,
 } = require("../volunteers.js");
 
 describe("findVolunteerByEmail", () => {
@@ -57,6 +60,52 @@ describe("findVolunteerByEmail", () => {
     test("it returns the error message", () => {
       expect(result[0]).toBeNull();
       expect(result[1]).toEqual(`Errors looking up volunteer by email ${email}: ${errorMessage}`);
+    });
+  });
+
+  describe("findVolunteerById", () => {
+    const id = 1234;
+    
+    beforeEach(async () => {
+      await findVolunteerById(id);
+    });
+
+    test("it sends a find request", () => {
+      expect(mockFindFn).toHaveBeenCalledWith(id);
+    });
+
+    describe("if the ID exists", () => {
+      const volunteer = "a volunteer";
+      let result;
+      
+      beforeEach(async () => {
+	
+	mockFindFn.mockResolvedValue(volunteer);
+
+	result = await findVolunteerById(id);
+      });
+
+      test("it returns the volunteer", () => {
+	expect(result[0]).toEqual(volunteer);
+	expect(result[1]).toBeNull();
+      });
+    });
+
+    describe("if the ID does ont exist", () => {
+      const error = "an error";
+      let result;
+
+      beforeEach(async () => {
+
+	mockFindFn.mockRejectedValue(error);
+
+	result = await findVolunteerById(id);
+      });
+
+      test("it returns the error message", () => {
+	expect(result[0]).toBeNull();
+	expect(result[1]).toEqual(`Errors looking up volunteer by recordId ${id}: ${error}`);
+      });
     });
   });
 });

--- a/src/lib/airtable/tables/__tests__/volunteers.test.js
+++ b/src/lib/airtable/tables/__tests__/volunteers.test.js
@@ -98,7 +98,7 @@ describe("findVolunteerByEmail", () => {
       });
     });
 
-    describe("if the ID does ont exist", () => {
+    describe("if the ID does not exist", () => {
       const error = "an error";
       let result;
 

--- a/src/lib/airtable/tables/__tests__/volunteers.test.js
+++ b/src/lib/airtable/tables/__tests__/volunteers.test.js
@@ -1,0 +1,30 @@
+const mockSelectFn = jest.fn();
+
+jest.mock("~airtable/bases", () => ({
+  airbase: () => ({
+    select: mockSelectFn,
+  }),
+}));
+
+const {
+  findVolunteerByEmail
+} = require("../volunteers.js");
+
+describe("findVolunteerByEmail", () => {
+  describe("when the email is not found", () => {
+    const email = "notreal@example.com";
+    let result;
+    
+    beforeEach(async () => {
+      
+      mockSelectFn.mockReturnValue({firstPage: () => []});
+      
+      result = await findVolunteerByEmail(email);
+    });
+
+    test("it returns an error message", () => {
+      expect(result[0]).toBeNull();
+      expect(result[1]).toEqual(expect.stringContaining(`No volunteer signed up with email ${email}`));
+    });
+  });
+});

--- a/src/lib/airtable/tables/__tests__/volunteers.test.js
+++ b/src/lib/airtable/tables/__tests__/volunteers.test.js
@@ -20,17 +20,18 @@ describe("findVolunteerByEmail", () => {
   describe("when the email is NOT found", () => {
     const email = "notreal@example.com";
     let result;
-    
+
     beforeEach(async () => {
-      
-      mockSelectFn.mockReturnValue({firstPage: () => []});
-      
+      mockSelectFn.mockReturnValue({ firstPage: () => [] });
+
       result = await findVolunteerByEmail(email);
     });
 
     test("it returns an error message", () => {
       expect(result[0]).toBeNull();
-      expect(result[1]).toEqual(expect.stringContaining(`No volunteer signed up with email ${email}`));
+      expect(result[1]).toEqual(
+        expect.stringContaining(`No volunteer signed up with email ${email}`)
+      );
     });
   });
 
@@ -38,7 +39,7 @@ describe("findVolunteerByEmail", () => {
     let result;
 
     beforeEach(async () => {
-      mockSelectFn.mockReturnValue({firstPage: () => ["a volunteer"]});
+      mockSelectFn.mockReturnValue({ firstPage: () => ["a volunteer"] });
 
       result = await findVolunteerByEmail("real@example.com");
     });
@@ -55,20 +56,24 @@ describe("findVolunteerByEmail", () => {
     let result;
 
     beforeEach(async () => {
-      mockSelectFn.mockReturnValue({firstPage: jest.fn().mockRejectedValue(errorMessage)});
+      mockSelectFn.mockReturnValue({
+        firstPage: jest.fn().mockRejectedValue(errorMessage),
+      });
 
       result = await findVolunteerByEmail(email);
     });
 
     test("it returns the error message", () => {
       expect(result[0]).toBeNull();
-      expect(result[1]).toEqual(`Errors looking up volunteer by email ${email}: ${errorMessage}`);
+      expect(result[1]).toEqual(
+        `Errors looking up volunteer by email ${email}: ${errorMessage}`
+      );
     });
   });
 
   describe("findVolunteerById", () => {
     const id = 1234;
-    
+
     beforeEach(async () => {
       await findVolunteerById(id);
     });
@@ -80,17 +85,16 @@ describe("findVolunteerByEmail", () => {
     describe("if the ID exists", () => {
       const volunteer = "a volunteer";
       let result;
-      
-      beforeEach(async () => {
-	
-	mockFindFn.mockResolvedValue(volunteer);
 
-	result = await findVolunteerById(id);
+      beforeEach(async () => {
+        mockFindFn.mockResolvedValue(volunteer);
+
+        result = await findVolunteerById(id);
       });
 
       test("it returns the volunteer", () => {
-	expect(result[0]).toEqual(volunteer);
-	expect(result[1]).toBeNull();
+        expect(result[0]).toEqual(volunteer);
+        expect(result[1]).toBeNull();
       });
     });
 
@@ -99,15 +103,16 @@ describe("findVolunteerByEmail", () => {
       let result;
 
       beforeEach(async () => {
+        mockFindFn.mockRejectedValue(error);
 
-	mockFindFn.mockRejectedValue(error);
-
-	result = await findVolunteerById(id);
+        result = await findVolunteerById(id);
       });
 
       test("it returns the error message", () => {
-	expect(result[0]).toBeNull();
-	expect(result[1]).toEqual(`Errors looking up volunteer by recordId ${id}: ${error}`);
+        expect(result[0]).toBeNull();
+        expect(result[1]).toEqual(
+          `Errors looking up volunteer by recordId ${id}: ${error}`
+        );
       });
     });
   });
@@ -117,25 +122,25 @@ describe("findVolunteerByEmail", () => {
       let result;
       const volunteer = "a volunteer";
       const phone = "123-555-4444";
-      
-      beforeEach(async () => {
-	mockSelectFn.mockReturnValue({
-	  firstPage: () => [volunteer]
-	});
 
-	result = await findVolunteerByPhone(phone);
+      beforeEach(async () => {
+        mockSelectFn.mockReturnValue({
+          firstPage: () => [volunteer],
+        });
+
+        result = await findVolunteerByPhone(phone);
       });
-      
+
       test("it returns the volunteer", () => {
-	expect(result[0]).toEqual(volunteer);
-	expect(result[1]).toBeNull();
+        expect(result[0]).toEqual(volunteer);
+        expect(result[1]).toBeNull();
       });
 
       test("it makes a select request by phone number", () => {
-	expect(mockSelectFn).toHaveBeenCalledWith({
-	  maxRecords: 1,
-	  filterByFormula: `FIND("1235554444", ${volunteersFields.phone}) > 0`
-	});
+        expect(mockSelectFn).toHaveBeenCalledWith({
+          maxRecords: 1,
+          filterByFormula: `FIND("1235554444", ${volunteersFields.phone}) > 0`,
+        });
       });
     });
     describe("when the phone number is NOT found", () => {
@@ -143,35 +148,39 @@ describe("findVolunteerByEmail", () => {
       const phone = "123-555-4444";
 
       beforeEach(async () => {
-	mockSelectFn.mockReturnValue({
-	  firstPage: () => []
-	});
-	
-	result = await findVolunteerByPhone(phone);
+        mockSelectFn.mockReturnValue({
+          firstPage: () => [],
+        });
+
+        result = await findVolunteerByPhone(phone);
       });
 
       test("it returns a 404 message", () => {
-	expect(result[0]).toBeNull();
-	expect(result[1]).toEqual(`404: No volunteer signed up with phone number ${phone}.`);
+        expect(result[0]).toBeNull();
+        expect(result[1]).toEqual(
+          `404: No volunteer signed up with phone number ${phone}.`
+        );
       });
     });
-    
+
     describe("when there is an error in the request", () => {
       let result;
       const error = "an error";
       const phone = "123-555-4444";
-      
-      beforeEach(async () => {
-	mockSelectFn.mockReturnValue({
-	  firstPage: jest.fn().mockRejectedValue(error)
-	});
 
-	result = await findVolunteerByPhone(phone);
+      beforeEach(async () => {
+        mockSelectFn.mockReturnValue({
+          firstPage: jest.fn().mockRejectedValue(error),
+        });
+
+        result = await findVolunteerByPhone(phone);
       });
 
       test("it returns the error message", () => {
-	expect(result[0]).toBeNull();
-	expect(result[1]).toEqual(`Errors looking up volunteer by phone number ${phone}: ${error}`);
+        expect(result[0]).toBeNull();
+        expect(result[1]).toEqual(
+          `Errors looking up volunteer by phone number ${phone}: ${error}`
+        );
       });
     });
   });

--- a/src/lib/airtable/tables/__tests__/volunteers.test.js
+++ b/src/lib/airtable/tables/__tests__/volunteers.test.js
@@ -11,7 +11,10 @@ jest.mock("~airtable/bases", () => ({
 const {
   findVolunteerByEmail,
   findVolunteerById,
+  findVolunteerByPhone,
 } = require("../volunteers.js");
+
+const { volunteersFields } = require("../volunteersSchema.js");
 
 describe("findVolunteerByEmail", () => {
   describe("when the email is NOT found", () => {
@@ -105,6 +108,70 @@ describe("findVolunteerByEmail", () => {
       test("it returns the error message", () => {
 	expect(result[0]).toBeNull();
 	expect(result[1]).toEqual(`Errors looking up volunteer by recordId ${id}: ${error}`);
+      });
+    });
+  });
+
+  describe("findVolunteerByPhone", () => {
+    describe("when the phone number IS found", () => {
+      let result;
+      const volunteer = "a volunteer";
+      const phone = "123-555-4444";
+      
+      beforeEach(async () => {
+	mockSelectFn.mockReturnValue({
+	  firstPage: () => [volunteer]
+	});
+
+	result = await findVolunteerByPhone(phone);
+      });
+      
+      test("it returns the volunteer", () => {
+	expect(result[0]).toEqual(volunteer);
+	expect(result[1]).toBeNull();
+      });
+
+      test("it makes a select request by phone number", () => {
+	expect(mockSelectFn).toHaveBeenCalledWith({
+	  maxRecords: 1,
+	  filterByFormula: `FIND("1235554444", ${volunteersFields.phone}) > 0`
+	});
+      });
+    });
+    describe("when the phone number is NOT found", () => {
+      let result;
+      const phone = "123-555-4444";
+
+      beforeEach(async () => {
+	mockSelectFn.mockReturnValue({
+	  firstPage: () => []
+	});
+	
+	result = await findVolunteerByPhone(phone);
+      });
+
+      test("it returns a 404 message", () => {
+	expect(result[0]).toBeNull();
+	expect(result[1]).toEqual(`404: No volunteer signed up with phone number ${phone}.`);
+      });
+    });
+    
+    describe("when there is an error in the request", () => {
+      let result;
+      const error = "an error";
+      const phone = "123-555-4444";
+      
+      beforeEach(async () => {
+	mockSelectFn.mockReturnValue({
+	  firstPage: jest.fn().mockRejectedValue(error)
+	});
+
+	result = await findVolunteerByPhone(phone);
+      });
+
+      test("it returns the error message", () => {
+	expect(result[0]).toBeNull();
+	expect(result[1]).toEqual(`Errors looking up volunteer by phone number ${phone}: ${error}`);
       });
     });
   });

--- a/src/lib/airtable/tables/volunteers.js
+++ b/src/lib/airtable/tables/volunteers.js
@@ -1,11 +1,16 @@
 const { airbase } = require("~airtable/bases");
 
+const {
+  volunteersTable,
+  volunteersFields,
+} = require("~airtable/tables/volunteersSchema");
+
 exports.findVolunteerByEmail = async (email) => {
   try {
     const records = await volunteersTable
       .select({
         filterByFormula: `(LOWER({${
-          fields.email
+          volunteersFields.email
         }}) = '${email.toLowerCase()}')`,
       })
       .firstPage();
@@ -38,7 +43,7 @@ exports.findVolunteerByPhone = async (phone) => {
     const records = await volunteersTable
       .select({
         maxRecords: 1,
-        filterByFormula: `FIND("${strippedPhone}", ${fields.phone}) > 0`,
+        filterByFormula: `FIND("${strippedPhone}", ${volunteersFields.phone}) > 0`,
       })
       .firstPage();
     const record = records && records.length ? records[0] : null;
@@ -52,65 +57,3 @@ exports.findVolunteerByPhone = async (phone) => {
     return [null, `Errors looking up volunteer by phone number ${phone}: ${e}`];
   }
 };
-
-// ==================================================================
-// Schema
-// ==================================================================
-
-const volunteersTableName = (exports.volunteersTableName = "Volunteers");
-const volunteersTable = (exports.volunteersTable = airbase(
-  volunteersTableName
-));
-const fields = (exports.volunteersFields = {
-  email: "volunteer_email",
-  phone: "volunteer_phone",
-  streetFirst: "volunteer_street_1",
-  streetSecond: "volunteer_street_2",
-  languages: "volunteer_languages",
-  languages_options: {
-    spanish: "Spanish",
-    french: "French",
-    english: "English",
-    russian: "Russian",
-    chinese: "Chinese",
-    german: "German",
-    arabic: "Arabic",
-    yiddish: "Yiddish",
-    bengali: "Bengali",
-    italian: "Italian",
-    korean: "Korean",
-    vietnamese: "Vietnamese",
-    hindi: "Hindi",
-    polski: "Polski",
-    portuguese: "Portuguese",
-  },
-  waysToHelp: "volunteer_ways_to_help",
-  waysToHelp_options: {
-    bikeDelivery: "Bike delivery",
-    carDelivery: "Car delivery",
-    financialSupport: "Financial support",
-    childCare: "Child care",
-    phoningNeighborsInNeed: "Phoning Neighbors in need",
-    onFootDelivery: "On foot delivery",
-    techAdminSupport: "Tech/admin support",
-    flyering: "Flyering",
-    iHaveAPrinter: "I have a printer!",
-    artsDesignFilm: "Arts/design/film",
-  },
-  extraInfo: "volunteer_extra_info",
-  slackId: "volunteer_slack_id",
-  deliveryRequests: "Requests: Delivery",
-  intakeRequests: "Requests: Intake",
-  quadrant: "volunteer_quadrant",
-  quadrant_options: {
-    northwest: "northwest",
-    southwest: "southwest",
-    northeast: "northeast",
-    southeast: "southeast",
-    iDontKnow: "i don't know",
-  },
-  name: "volunter_name",
-  howFound: "volunteer_howfind",
-  trained: "volunteer_trained",
-  createdTime: "Created Time",
-});

--- a/src/lib/airtable/tables/volunteers.js
+++ b/src/lib/airtable/tables/volunteers.js
@@ -1,5 +1,3 @@
-const { airbase } = require("~airtable/bases");
-
 const {
   volunteersTable,
   volunteersFields,

--- a/src/lib/airtable/tables/volunteersSchema.js
+++ b/src/lib/airtable/tables/volunteersSchema.js
@@ -1,10 +1,8 @@
 const { airbase } = require("~airtable/bases");
 
 const volunteersTableName = (exports.volunteersTableName = "Volunteers");
-const volunteersTable = (exports.volunteersTable = airbase(
-  volunteersTableName
-));
-const fields = (exports.volunteersFields = {
+exports.volunteersTable = airbase(volunteersTableName);
+exports.volunteersFields = {
   email: "volunteer_email",
   phone: "volunteer_phone",
   streetFirst: "volunteer_street_1",
@@ -56,4 +54,4 @@ const fields = (exports.volunteersFields = {
   howFound: "volunteer_howfind",
   trained: "volunteer_trained",
   createdTime: "Created Time",
-});
+};

--- a/src/lib/airtable/tables/volunteersSchema.js
+++ b/src/lib/airtable/tables/volunteersSchema.js
@@ -1,0 +1,59 @@
+const { airbase } = require("~airtable/bases");
+
+const volunteersTableName = (exports.volunteersTableName = "Volunteers");
+const volunteersTable = (exports.volunteersTable = airbase(
+  volunteersTableName
+));
+const fields = (exports.volunteersFields = {
+  email: "volunteer_email",
+  phone: "volunteer_phone",
+  streetFirst: "volunteer_street_1",
+  streetSecond: "volunteer_street_2",
+  languages: "volunteer_languages",
+  languages_options: {
+    spanish: "Spanish",
+    french: "French",
+    english: "English",
+    russian: "Russian",
+    chinese: "Chinese",
+    german: "German",
+    arabic: "Arabic",
+    yiddish: "Yiddish",
+    bengali: "Bengali",
+    italian: "Italian",
+    korean: "Korean",
+    vietnamese: "Vietnamese",
+    hindi: "Hindi",
+    polski: "Polski",
+    portuguese: "Portuguese",
+  },
+  waysToHelp: "volunteer_ways_to_help",
+  waysToHelp_options: {
+    bikeDelivery: "Bike delivery",
+    carDelivery: "Car delivery",
+    financialSupport: "Financial support",
+    childCare: "Child care",
+    phoningNeighborsInNeed: "Phoning Neighbors in need",
+    onFootDelivery: "On foot delivery",
+    techAdminSupport: "Tech/admin support",
+    flyering: "Flyering",
+    iHaveAPrinter: "I have a printer!",
+    artsDesignFilm: "Arts/design/film",
+  },
+  extraInfo: "volunteer_extra_info",
+  slackId: "volunteer_slack_id",
+  deliveryRequests: "Requests: Delivery",
+  intakeRequests: "Requests: Intake",
+  quadrant: "volunteer_quadrant",
+  quadrant_options: {
+    northwest: "northwest",
+    southwest: "southwest",
+    northeast: "northeast",
+    southeast: "southeast",
+    iDontKnow: "i don't know",
+  },
+  name: "volunter_name",
+  howFound: "volunteer_howfind",
+  trained: "volunteer_trained",
+  createdTime: "Created Time",
+});

--- a/src/lib/slack/constants.js
+++ b/src/lib/slack/constants.js
@@ -1,4 +1,4 @@
-const { volunteersFields } = require("~airtable/tables/volunteers");
+const { volunteersFields } = require("~airtable/tables/volunteersSchema");
 const { str } = require("~strings/i18nextWrappers");
 
 exports.APP_NAME = process.env.APP_NAME || str("common:appName");

--- a/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
+++ b/src/workers/airtable-sync/actions/payments/newPaymentRequest.js
@@ -1,10 +1,8 @@
 const slackapi = require("~slack/webApi");
 const { findChannelByName, addBotToChannel } = require("~slack/channels");
 const { REIMBURSEMENT_CHANNEL } = require("~slack/constants");
-const {
-  volunteersFields,
-  findVolunteerById,
-} = require("~airtable/tables/volunteers");
+const { findVolunteerById } = require("~airtable/tables/volunteers");
+const { volunteersFields } = require("~airtable/tables/volunteersSchema");
 const {
   paymentRequestsFields,
   paymentRequestsTable,


### PR DESCRIPTION
This PR splits the table schema from the library of useful functions for the Volunteers table. I did my best to follow the patterns established in previous test PRs but I think there are some improvements here. Also, the coverage tool reports 100% coverage, which is nice! Run with `npm test`.