### PR TITLE
Improve coverage for existing airtable test suites

### DIFF
--- a/src/lib/airtable/tables/__tests__/donorPayments.test.js
+++ b/src/lib/airtable/tables/__tests__/donorPayments.test.js
@@ -89,4 +89,22 @@ describe("findDonorPaymentByCode", () => {
       expect(result).toEqual([null, "Valid payment with that code not found"]);
     });
   });
+
+  describe("when an error occurs", () => {
+    let result;
+    const error = { message: "an error" };
+
+    beforeEach(async () => {
+      mockSelect.mockReturnValue({
+        firstPage: jest.fn().mockRejectedValue(error),
+      });
+
+      result = await findDonorPaymentByCode("abcd");
+    });
+
+    test("it returns the error message", () => {
+      expect(result[0]).toBeNull();
+      expect(result[1]).toEqual(error.message);
+    });
+  });
 });

--- a/src/lib/airtable/tables/__tests__/paymentRequests.test.js
+++ b/src/lib/airtable/tables/__tests__/paymentRequests.test.js
@@ -1,7 +1,11 @@
+const mockSelectFn = jest.fn();
+const mockUpdateFn = jest.fn();
 const mockDestroyFn = jest.fn();
 
 jest.mock("~airtable/bases", () => ({
   paymentsAirbase: () => ({
+    select: mockSelectFn,
+    update: mockUpdateFn,
     destroy: mockDestroyFn,
   }),
 }));
@@ -9,19 +13,66 @@ jest.mock("~airtable/bases", () => ({
 const { Record } = require("airtable");
 const {
   deletePaymentRequest,
-  paymentRequestsTableName,
+  updatePaymentRequestByCode,
 } = require("../paymentRequests");
+const {
+  paymentRequestsTableName,
+  paymentRequestsFields,
+} = require("../paymentRequestsSchema");
+
+describe("updatePaymentRequestByCode", () => {
+  describe("when a payment request exists for the given code", () => {
+    let code, update, result;
+    
+    beforeAll(async () => {
+      code = "123";
+      update = { [paymentRequestsFields.balance]: "100" };
+
+      mockSelectFn.mockReturnValue({
+	firstPage: () => "a record"
+      });
+
+      mockUpdateFn.mockReturnValue(["an updated record"]);
+      
+      result = await updatePaymentRequestByCode(code, update);
+    });
+    
+    test("it returns the payment request record", () => {
+      expect(result[0]).toEqual("an updated record");
+      expect(result[1]).toBeNull();
+    });
+  });
+});
 
 describe("deletePaymentRequest", () => {
   let paymentRequestRecord;
 
-  beforeEach(() => {
+  beforeAll(async () => {
     paymentRequestRecord = new Record(paymentRequestsTableName, "some-id");
+    await deletePaymentRequest(paymentRequestRecord);
   });
 
-  test("sends a delete request to the Payment Request table", async () => {
-    await deletePaymentRequest(paymentRequestRecord);
-
+  test("it sends a delete request to the Payment Request table", () => {
     expect(mockDestroyFn).toHaveBeenCalledWith(paymentRequestRecord.id);
+  });
+
+  describe("when an error occurs", () => {
+    const error = "an error";
+    let consoleErrorFn;
+    
+    beforeAll(async () => {
+      consoleErrorFn = console.error;
+      console.error = jest.fn();
+      mockDestroyFn.mockRejectedValue(error);
+      await deletePaymentRequest(paymentRequestRecord);
+    });
+
+    afterAll(() => {
+      console.error = consoleErrorFn;
+    });
+
+    test("it logs the error", () => {
+      expect(console.error).toHaveBeenCalledWith(`Error while deleting payment request ${error}`);
+    });
   });
 });

--- a/src/lib/airtable/tables/__tests__/paymentRequests.test.js
+++ b/src/lib/airtable/tables/__tests__/paymentRequests.test.js
@@ -22,43 +22,47 @@ const {
 } = require("../paymentRequestsSchema");
 
 describe("updatePaymentRequestByCode", () => {
-
   afterAll(jest.clearAllMocks);
-  
+
   describe("when a payment request exists for the given code", () => {
-    let code, update, result, record;
-    
+    let code;
+    let update;
+    let result;
+    let record;
+
     beforeAll(async () => {
       code = "123";
       update = { [paymentRequestsFields.balance]: "100" };
-      
+
       record = new Record(paymentRequestsTableName, "id-50", {
-	[paymentRequestsFields.amount]: "150",
-	[paymentRequestsFields.balance]: "150"
+        [paymentRequestsFields.amount]: "150",
+        [paymentRequestsFields.balance]: "150",
       });
-      
+
       mockSelectFn.mockReturnValue({ firstPage: () => [record] });
 
       mockUpdateFn.mockReturnValue(["an updated record"]);
-      
+
       result = await updatePaymentRequestByCode(code, update);
     });
 
     test("it sends a select request", () => {
       expect(mockSelectFn).toHaveBeenCalledWith({
-	filterByFormula: `(FIND('${code}', {${paymentRequestsFields.requestCode}}) > 0)`
+        filterByFormula: `(FIND('${code}', {${paymentRequestsFields.requestCode}}) > 0)`,
       });
     });
 
     test("it sends an update request with the new values", () => {
-      expect(mockUpdateFn).toHaveBeenCalledWith([{
-	id: record.id,
-	fields: {
-	  [paymentRequestsFields.balance]: "100"
-	}
-      }]);
+      expect(mockUpdateFn).toHaveBeenCalledWith([
+        {
+          id: record.id,
+          fields: {
+            [paymentRequestsFields.balance]: "100",
+          },
+        },
+      ]);
     });
-    
+
     test("it returns the payment request record", () => {
       expect(result[0]).toEqual("an updated record");
       expect(result[1]).toBeNull();
@@ -68,7 +72,7 @@ describe("updatePaymentRequestByCode", () => {
   describe("when no payment request exists for the given code", () => {
     let result;
     const code = "some code";
-    
+
     beforeAll(async () => {
       mockSelectFn.mockReturnValue({ firstPage: () => [] });
 
@@ -87,12 +91,12 @@ describe("updatePaymentRequestByCode", () => {
 
     beforeAll(async () => {
       mockSelectFn.mockReturnValue({
-	firstPage: jest.fn().mockRejectedValue(error)
+        firstPage: jest.fn().mockRejectedValue(error),
       });
 
       result = await updatePaymentRequestByCode("some code", "some update");
     });
-    
+
     test("it returns the error message", () => {
       expect(result[0]).toBeNull();
       expect(result[1]).toEqual(`Error while processing update: ${error}`);
@@ -105,7 +109,7 @@ describe("updatePaymentRequestByCode", () => {
 
     beforeAll(async () => {
       mockSelectFn.mockReturnValue({
-	firstPage: () => [new Record(paymentRequestsTableName, "some-id")]
+        firstPage: () => [new Record(paymentRequestsTableName, "some-id")],
       });
 
       mockUpdateFn.mockRejectedValue(error);
@@ -121,17 +125,15 @@ describe("updatePaymentRequestByCode", () => {
 });
 
 describe("findPaymentRequestInSlack", () => {
-
   afterAll(jest.clearAllMocks);
-  
+
   describe("given a code that is too short", () => {
-    
     let result;
-    
+
     beforeAll(async () => {
       result = await findPaymentRequestInSlack("ABC");
     });
-    
+
     test("it returns an error message", () => {
       expect(result[0]).toBeNull();
       expect(result[1]).toEqual("Request code must be at least 4 characters.");
@@ -148,7 +150,7 @@ describe("findPaymentRequestInSlack", () => {
 
     test("it sends a select request", () => {
       expect(mockSelectFn).toHaveBeenCalledWith({
-	filterByFormula: `AND((FIND('${code}', {${paymentRequestsFields.requestCode}}) > 0), {${paymentRequestsFields.slackThreadId}})`
+        filterByFormula: `AND((FIND('${code}', {${paymentRequestsFields.requestCode}}) > 0), {${paymentRequestsFields.slackThreadId}})`,
       });
     });
 
@@ -156,16 +158,16 @@ describe("findPaymentRequestInSlack", () => {
       let result;
 
       beforeAll(async () => {
-	mockSelectFn.mockReturnValue({
-	  firstPage: () => []
-	});
+        mockSelectFn.mockReturnValue({
+          firstPage: () => [],
+        });
 
-	result = await findPaymentRequestInSlack(code);
+        result = await findPaymentRequestInSlack(code);
       });
 
       test("it returns an error message", () => {
-	expect(result[0]).toBeNull();
-	expect(result[1]).toEqual("No paymentrequests found with that code.");
+        expect(result[0]).toBeNull();
+        expect(result[1]).toEqual("No paymentrequests found with that code.");
       });
     });
 
@@ -174,16 +176,16 @@ describe("findPaymentRequestInSlack", () => {
       const error = "an error";
 
       beforeAll(async () => {
-	mockSelectFn.mockReturnValue({
-	  firstPage: jest.fn().mockRejectedValue(error)
-	});
+        mockSelectFn.mockReturnValue({
+          firstPage: jest.fn().mockRejectedValue(error),
+        });
 
-	result = await findPaymentRequestInSlack(code);
+        result = await findPaymentRequestInSlack(code);
       });
 
       test("it returns the error message", () => {
-	expect(result[0]).toBeNull();
-	expect(result[1]).toEqual(`Error while finding request: ${error}`);
+        expect(result[0]).toBeNull();
+        expect(result[1]).toEqual(`Error while finding request: ${error}`);
       });
     });
 
@@ -192,25 +194,24 @@ describe("findPaymentRequestInSlack", () => {
       const record = "a payment request record";
 
       beforeAll(async () => {
-	mockSelectFn.mockReturnValue({
-	  firstPage: () => [record]
-	});
+        mockSelectFn.mockReturnValue({
+          firstPage: () => [record],
+        });
 
-	result = await findPaymentRequestInSlack(code);
+        result = await findPaymentRequestInSlack(code);
       });
-      
+
       test("it returns the payment request record", () => {
-	expect(result[0]).toEqual(record);
-	expect(result[1]).toBeNull();
+        expect(result[0]).toEqual(record);
+        expect(result[1]).toBeNull();
       });
     });
   });
 });
 
 describe("deletePaymentRequest", () => {
-
   afterAll(jest.clearAllMocks);
-  
+
   let paymentRequestRecord;
 
   beforeAll(async () => {
@@ -225,7 +226,7 @@ describe("deletePaymentRequest", () => {
   describe("when an error occurs", () => {
     const error = "an error";
     let consoleErrorFn;
-    
+
     beforeAll(async () => {
       consoleErrorFn = console.error;
       console.error = jest.fn();
@@ -238,7 +239,9 @@ describe("deletePaymentRequest", () => {
     });
 
     test("it logs the error", () => {
-      expect(console.error).toHaveBeenCalledWith(`Error while deleting payment request ${error}`);
+      expect(console.error).toHaveBeenCalledWith(
+        `Error while deleting payment request ${error}`
+      );
     });
   });
 });

--- a/src/lib/airtable/tables/__tests__/paymentRequests.test.js
+++ b/src/lib/airtable/tables/__tests__/paymentRequests.test.js
@@ -22,24 +22,96 @@ const {
 
 describe("updatePaymentRequestByCode", () => {
   describe("when a payment request exists for the given code", () => {
-    let code, update, result;
+    let code, update, result, record;
     
     beforeAll(async () => {
       code = "123";
       update = { [paymentRequestsFields.balance]: "100" };
-
-      mockSelectFn.mockReturnValue({
-	firstPage: () => "a record"
+      
+      record = new Record(paymentRequestsTableName, "id-50", {
+	[paymentRequestsFields.amount]: "150",
+	[paymentRequestsFields.balance]: "150"
       });
+      
+      mockSelectFn.mockReturnValue({ firstPage: () => [record] });
 
       mockUpdateFn.mockReturnValue(["an updated record"]);
       
       result = await updatePaymentRequestByCode(code, update);
     });
+
+    test("it sends a select request", () => {
+      expect(mockSelectFn).toHaveBeenCalledWith({
+	filterByFormula: `(FIND('${code}', {${paymentRequestsFields.requestCode}}) > 0)`
+      });
+    });
+
+    test("it sends an update request with the new values", () => {
+      expect(mockUpdateFn).toHaveBeenCalledWith([{
+	id: record.id,
+	fields: {
+	  [paymentRequestsFields.balance]: "100"
+	}
+      }]);
+    });
     
     test("it returns the payment request record", () => {
       expect(result[0]).toEqual("an updated record");
       expect(result[1]).toBeNull();
+    });
+  });
+
+  describe("when no payment request exists for the given code", () => {
+    let result;
+    const code = "some code";
+    
+    beforeAll(async () => {
+      mockSelectFn.mockReturnValue({ firstPage: () => [] });
+
+      result = await updatePaymentRequestByCode(code, "some update");
+    });
+
+    test("it returns an error message", () => {
+      expect(result[0]).toBeNull();
+      expect(result[1]).toEqual(`No requests found with code: ${code}`);
+    });
+  });
+
+  describe("when an error occurs in the select request", () => {
+    let result;
+    const error = "a select error message";
+
+    beforeAll(async () => {
+      mockSelectFn.mockReturnValue({
+	firstPage: jest.fn().mockRejectedValue(error)
+      });
+
+      result = await updatePaymentRequestByCode("some code", "some update");
+    });
+    
+    test("it returns the error message", () => {
+      expect(result[0]).toBeNull();
+      expect(result[1]).toEqual(`Error while processing update: ${error}`);
+    });
+  });
+
+  describe("when an error occurs in the update request", () => {
+    let result;
+    const error = "an update error message";
+
+    beforeAll(async () => {
+      mockSelectFn.mockReturnValue({
+	firstPage: () => [new Record(paymentRequestsTableName, "some-id")]
+      });
+
+      mockUpdateFn.mockRejectedValue(error);
+
+      result = await updatePaymentRequestByCode("some code", "some update");
+    });
+
+    test("it returns the error message", () => {
+      expect(result[0]).toBeNull();
+      expect(result[1]).toEqual(`Error while processing update: ${error}`);
     });
   });
 });

--- a/src/lib/airtable/tables/__tests__/paymentRequests.test.js
+++ b/src/lib/airtable/tables/__tests__/paymentRequests.test.js
@@ -219,7 +219,7 @@ describe("findPaymentRequestBySlackThreadId", () => {
 
     beforeAll(async () => {
       mockSelectFn.mockReturnValue({
-	firstPage: () => [record]
+        firstPage: () => [record],
       });
 
       result = await findPaymentRequestBySlackThreadId("some slack thread ID");
@@ -233,11 +233,10 @@ describe("findPaymentRequestBySlackThreadId", () => {
 
   describe("when NO payment request with the given slack thread is found", () => {
     let result;
-    const error = "some error message";
 
     beforeAll(async () => {
       mockSelectFn.mockReturnValue({
-	firstPage: () => null
+        firstPage: () => null,
       });
 
       result = await findPaymentRequestBySlackThreadId("some slack thread ID");
@@ -257,9 +256,9 @@ describe("findPaymentRequestBySlackThreadId", () => {
     beforeAll(async () => {
       consoleErrorFn = console.error;
       console.error = jest.fn();
-      
+
       mockSelectFn.mockReturnValue({
-	firstPage: jest.fn().mockRejectedValue(error)
+        firstPage: jest.fn().mockRejectedValue(error),
       });
 
       result = await findPaymentRequestBySlackThreadId("some slack thread ID");
@@ -275,7 +274,9 @@ describe("findPaymentRequestBySlackThreadId", () => {
     });
 
     test("it logs the error message", () => {
-      expect(console.error).toHaveBeenCalledWith(`Error while fetching request by thread ID: ${error}`);
+      expect(console.error).toHaveBeenCalledWith(
+        `Error while fetching request by thread ID: ${error}`
+      );
     });
   });
 });

--- a/src/lib/airtable/tables/__tests__/requests.test.js
+++ b/src/lib/airtable/tables/__tests__/requests.test.js
@@ -79,15 +79,15 @@ describe("deleteRequest", () => {
 describe("createRequest", () => {
   const message = "some test message";
   const source = "some test source";
-  
+
   describe("given the minimum required fields", () => {
     let result;
-    
+
     beforeAll(async () => {
       mockCreateFn.mockResolvedValue("the created record");
       result = await createRequest({ message, source });
     });
-    
+
     test("creates and returns a request with defaults", async () => {
       expect(mockCreateFn).toHaveBeenCalledWith({
         [fields.message]: message,
@@ -108,11 +108,11 @@ describe("createRequest", () => {
   describe("when an error occurs", () => {
     let result;
     const error = "an error message";
-    
+
     beforeAll(async () => {
       mockCreateFn.mockRejectedValue(error);
 
-      result = await createRequest({message, source});
+      result = await createRequest({ message, source });
     });
 
     test("it returns the error message", () => {
@@ -234,7 +234,7 @@ describe("findDeliveryNeededRequests", () => {
 
     beforeEach(async () => {
       mockSelectFn.mockReturnValue({
-	all: jest.fn().mockRejectedValue(error)
+        all: jest.fn().mockRejectedValue(error),
       });
 
       result = await findDeliveryNeededRequests();
@@ -242,7 +242,9 @@ describe("findDeliveryNeededRequests", () => {
 
     test("it returns the error message", () => {
       expect(result[0]).toEqual([]);
-      expect(result[1]).toEqual(`Error while looking up open requests: ${error}`);
+      expect(result[1]).toEqual(
+        `Error while looking up open requests: ${error}`
+      );
     });
   });
 });
@@ -307,7 +309,7 @@ describe("findOpenRequestsForSlack", () => {
 
     beforeAll(async () => {
       mockSelectFn.mockReturnValue({
-	all: jest.fn().mockRejectedValue(error)
+        all: jest.fn().mockRejectedValue(error),
       });
 
       result = await findOpenRequestsForSlack();
@@ -315,7 +317,9 @@ describe("findOpenRequestsForSlack", () => {
 
     test("it returns the error message", () => {
       expect(result[0]).toEqual([]);
-      expect(result[1]).toEqual(`Error while looking up open requests: ${error}`);
+      expect(result[1]).toEqual(
+        `Error while looking up open requests: ${error}`
+      );
     });
   });
 });


### PR DESCRIPTION
This PR increases test coverage in existing airtable function library test files to 100%! You can check coverage yourself with:
`npx jest src/lib/airtable/tables/__tests__/ --coverage`

For those wondering why I'm using `npx` here, I can't actually figure out how to use the `jest` executable otherwise, even though I'm pretty sure that's what `react-scripts` is using.