### PR TITLE
Add locale JSON validation

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,3 +26,4 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm test
+    - run: npm run i18n:validate

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "eslint src scripts",
     "fix": "eslint --fix src scripts",
     "find-new-strings": "i18next-scanner --config ./src/lib/strings/__i18nextScanner.config.js 'scripts/**/*.js' 'src/**/*.js'",
+    "i18n:validate": "node scripts/validateLocaleFiles.js",
     "local": "npm run local:react & npm run local:express",
     "local:express": "NODE_ENV=dev node index.js",
     "local:slack": "NODE_ENV=dev ngrok http 5000",

--- a/scripts/validateLocaleFiles.js
+++ b/scripts/validateLocaleFiles.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const path = require("path");
+
+function isValid(str) {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return e;
+  }
+}
+
+function validateFile(filePath) {
+  const data = fs.readFileSync(filePath, 'utf8');
+  const error = isValid(data);
+
+  if (error) {
+    console.error("Error in file: ", filePath);
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+const localesPath = "./src/lib/strings/locales";
+
+const dirs = fs.readdirSync(localesPath);
+dirs.forEach(dir => {
+  const files = fs.readdirSync(path.join(localesPath, dir));
+  files.forEach(file => {
+    validateFile(path.join(localesPath, dir, file));
+  });
+});

--- a/scripts/validateLocaleFiles.js
+++ b/scripts/validateLocaleFiles.js
@@ -7,10 +7,12 @@ function isValid(str) {
   } catch (e) {
     return e;
   }
+
+  return null;
 }
 
 function validateFile(filePath) {
-  const data = fs.readFileSync(filePath, 'utf8');
+  const data = fs.readFileSync(filePath, "utf8");
   const error = isValid(data);
 
   if (error) {
@@ -23,9 +25,9 @@ function validateFile(filePath) {
 const localesPath = "./src/lib/strings/locales";
 
 const dirs = fs.readdirSync(localesPath);
-dirs.forEach(dir => {
+dirs.forEach((dir) => {
   const files = fs.readdirSync(path.join(localesPath, dir));
-  files.forEach(file => {
+  files.forEach((file) => {
     validateFile(path.join(localesPath, dir, file));
   });
 });


### PR DESCRIPTION
This PR adds a script to check locale files for invalid JSON. A successful run will produce no output, while a failure will log the offending file with failure details and exit with a failure code. This failure code should trigger a red build in CI. The script can be run with `npm run i18n:validate`. This PR also adds this check to CI.

Closes #176 