### PR TITLE
Handle airtable services field to take either string or array

### DIFF
--- a/src/lib/airtable/deliveryrequests/getDeliveryRequestNeedFormatted.js
+++ b/src/lib/airtable/deliveryrequests/getDeliveryRequestNeedFormatted.js
@@ -9,13 +9,15 @@ exports.getDeliveryRequestNeedFormatted = (services) => {
   if (!services) {
     return "Not stated";
   }
-  let servicesString = ""
 
-  if (typeof services === "string"){
-    servicesString = services
-  } else if (Array.isArray(services)){
-    servicesString = services.join()
+  let servicesString = "";
+
+  if (typeof services === "string") {
+    servicesString = services;
+  } else if (Array.isArray(services)) {
+    servicesString = services.join();
   }
+
   if (servicesString === fields.supportType_options.delivery) {
     return "Groceries / Shopping";
   }

--- a/src/lib/airtable/deliveryrequests/getDeliveryRequestNeedFormatted.js
+++ b/src/lib/airtable/deliveryrequests/getDeliveryRequestNeedFormatted.js
@@ -15,7 +15,7 @@ exports.getDeliveryRequestNeedFormatted = (services) => {
   if (typeof services === "string") {
     servicesString = services;
   } else if (Array.isArray(services)) {
-    servicesString = services.join();
+    servicesString = services.join(", ");
   }
 
   if (servicesString === fields.supportType_options.delivery) {

--- a/src/lib/airtable/deliveryrequests/getDeliveryRequestNeedFormatted.js
+++ b/src/lib/airtable/deliveryrequests/getDeliveryRequestNeedFormatted.js
@@ -6,10 +6,16 @@
 const { fields } = require("~airtable/tables/requestsSchema");
 
 exports.getDeliveryRequestNeedFormatted = (services) => {
-  if (services === undefined) {
+  if (!services) {
     return "Not stated";
   }
-  const servicesString = services.join(", ");
+  let servicesString = ""
+
+  if (typeof services === "string"){
+    servicesString = services
+  } else if (Array.isArray(services)){
+    servicesString = services.join()
+  }
   if (servicesString === fields.supportType_options.delivery) {
     return "Groceries / Shopping";
   }


### PR DESCRIPTION
We are planning to change “What type(s) of support are you seeking?” field from a MULTI-SELECT to a SINGLE SELECT. This means the value is going from an array to a string. 

This patch will handle either case so things won't break when we switch over.