### PR TITLE
Remove sms_pickup=true check 

### DIFF
--- a/src/lib/strings/locales/en/slackapp.json
+++ b/src/lib/strings/locales/en/slackapp.json
@@ -154,7 +154,7 @@
       },
       "message": {
         "intro": "Hey Crown Heights, we have a new request from our neighbor {{firstName}} at {{streets}} in *{{quadrant}}*",
-        "outro": "*Want to volunteer to help our neighbor{{firstName}}?* Head to our <https://crownheightsma.herokuapp.com/delivery-needed?sms_pickup=true|online SMS pickup map> to find the code and click “Claim Delivery”!\n_Reminder: Please don’t volunteer for delivery if you have any COVID-19/cold/flu-like symptoms, or have come into contact with someone that’s tested positive. If you have been in large crowds or demonstrations, please self-isolate for 14 days or wait 5 days to get a test, and resume deliveries after testing negative._",
+        "outro": "*Want to volunteer to help our neighbor{{firstName}}?* Head to our <https://crownheightsma.herokuapp.com/delivery-needed|online SMS pickup map> to find the code and click “Claim Delivery”!\n_Reminder: Please don’t volunteer for delivery if you have any COVID-19/cold/flu-like symptoms, or have come into contact with someone that’s tested positive. If you have been in large crowds or demonstrations, please self-isolate for 14 days or wait 5 days to get a test, and resume deliveries after testing negative._",
         "outroPay": "Submit your receipt: please fill out this handy reimbursement form, it will automatically post to the #community_reimbursement channel!\nFor more information, please see the delivery guide.",
         "guide": "For more information, please see the <{{- guideUrl}}|delivery guide>."
       },

--- a/src/webapp/components/ClaimDeliveryButton.js
+++ b/src/webapp/components/ClaimDeliveryButton.js
@@ -3,17 +3,12 @@ import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 import { useTranslation } from "react-i18next";
 import DeliveryContext from "../context/DeliveryContext";
-import getParam from "../helpers/utils";
 
 const ClaimDeliveryButton = ({ className, requestCode }) => {
   const { t: str } = useTranslation();
 
   const deliveryContext = useContext(DeliveryContext);
-  const showSmsPickup = getParam("sms_pickup") === "true";
 
-  if (!showSmsPickup) {
-    return null;
-  }
   return (
     <Button
       size="small"


### PR DESCRIPTION
Remove 'sms_pickup' param used to previously hide a now-implemented beta feature which is now in the default user workflow.

Fixes issue #181 