### PR TITLE
Add new ioby reimbursement notice

### DIFF
--- a/src/webapp/components/DeliveryDialog/DialogScreens.js
+++ b/src/webapp/components/DeliveryDialog/DialogScreens.js
@@ -13,8 +13,9 @@ import CheckCircleIcon from "@material-ui/icons/CheckCircle";
 import Alert from "@material-ui/lab/Alert";
 import Collapse from "@material-ui/core/Collapse";
 import Link from "@material-ui/core/Link";
+import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
 import Instructions from "./Instructions";
-import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt';
+
 const useStyles = makeStyles((theme) => ({
   ...sharedStylesFn(theme),
   infoActionsContainer: {
@@ -43,6 +44,8 @@ export const InfoStep = ({ handleAccept, requestCode }) => {
   const classes = useStyles();
   const { t: str } = useTranslation();
   const [showReimbursementAlert, setShowReimbursementAlert] = useState();
+  const toggleReimbursement = () =>
+    setShowReimbursementAlert(!showReimbursementAlert);
   return (
     <>
       <DialogTitle>
@@ -54,24 +57,19 @@ export const InfoStep = ({ handleAccept, requestCode }) => {
         <Box mb={2}>
           <Alert severity="warning">
             <Typography variant="body2">
-              Important temporary reimbursement policy change: There is a weekly cap for
-              the disbursement of ioby raised funds.
-{" "}
-              <Link
-                href="#"
-                onClick={() =>
-                  setShowReimbursementAlert(!showReimbursementAlert)}
-              >
-              <span>Click to read more</span> <ArrowRightAltIcon fontSize="inherit"/>
+              {`Important temporary reimbursement policy change: There is a weekly
+              cap for the disbursement of ioby raised funds. `}
+              <Link href="#" onClick={toggleReimbursement}>
+                <span>Click to read more</span>
+                <ArrowRightAltIcon fontSize="inherit" />
               </Link>
               .
             </Typography>
             <Collapse in={showReimbursementAlert}>
               <Box mt={2}>
                 <Typography variant="body2" gutterBottom>
-                  The amount available and left each week from ioby funds can be
-                  seen
-  {" "}
+                  {`The amount available and left each week from ioby funds can be
+                  seen `}
                   <a
                     target="_blank"
                     rel="noopener noreferrer"
@@ -85,8 +83,9 @@ export const InfoStep = ({ handleAccept, requestCode }) => {
                 </Typography>
 
                 <Typography variant="body2" gutterBottom>
-                <strong>Why is this happening? </strong>This is a temporary measure so that we
-                  can stretch our funding a little longer. More details{" "}
+                  <strong>Why is this happening? </strong>
+                  {`This is a temporary measure so that we can stretch our funding
+                  a little longer. More details `}
                   <a
                     target="_blank"
                     rel="noopener noreferrer"

--- a/src/webapp/components/DeliveryDialog/DialogScreens.js
+++ b/src/webapp/components/DeliveryDialog/DialogScreens.js
@@ -10,8 +10,11 @@ import DialogActions from "@material-ui/core/DialogActions";
 import Button from "@material-ui/core/Button";
 import Box from "@material-ui/core/Box";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import Alert from "@material-ui/lab/Alert";
+import Collapse from "@material-ui/core/Collapse";
+import Link from "@material-ui/core/Link";
 import Instructions from "./Instructions";
-
+import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt';
 const useStyles = makeStyles((theme) => ({
   ...sharedStylesFn(theme),
   infoActionsContainer: {
@@ -39,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
 export const InfoStep = ({ handleAccept, requestCode }) => {
   const classes = useStyles();
   const { t: str } = useTranslation();
-
+  const [showReimbursementAlert, setShowReimbursementAlert] = useState();
   return (
     <>
       <DialogTitle>
@@ -48,6 +51,55 @@ export const InfoStep = ({ handleAccept, requestCode }) => {
         })}
       </DialogTitle>
       <DialogContent>
+        <Box mb={2}>
+          <Alert severity="warning">
+            <Typography variant="body2">
+              Important temporary reimbursement policy change: There is a weekly cap for
+              the disbursement of ioby raised funds.
+{" "}
+              <Link
+                href="#"
+                onClick={() =>
+                  setShowReimbursementAlert(!showReimbursementAlert)}
+              >
+              <span>Click to read more</span> <ArrowRightAltIcon fontSize="inherit"/>
+              </Link>
+              .
+            </Typography>
+            <Collapse in={showReimbursementAlert}>
+              <Box mt={2}>
+                <Typography variant="body2" gutterBottom>
+                  The amount available and left each week from ioby funds can be
+                  seen
+  {" "}
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://airtable.com/shr7FfnC4AAwEl6XH/tbluNmyS5qqbNAOPW"
+                  >
+                    here
+                  </a>
+                  . Ioby funds will be disbursed in order of requests received.
+                  Internal slack crowdsourcing and the CHMA hat are not included
+                  in the cap though!
+                </Typography>
+
+                <Typography variant="body2" gutterBottom>
+                <strong>Why is this happening? </strong>This is a temporary measure so that we
+                  can stretch our funding a little longer. More details{" "}
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://docs.google.com/document/d/1-scRL2GAL-DT6Ohm5GpmilmiEm2lh9AT7k3Ew4fPQxA/edit?usp=sharing"
+                  >
+                    here
+                  </a>
+                </Typography>
+              </Box>
+            </Collapse>
+          </Alert>
+        </Box>
+
         <Box mb={2}>
           <Typography variant="body2">
             {str("webapp:deliveryNeeded.dialog.condition", {
@@ -75,7 +127,7 @@ export const InfoStep = ({ handleAccept, requestCode }) => {
             <Trans key="webapp:deliveryNeeded.dialog.deliverySlip">
               <strong>
                 {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-                UPDATE: If you have access to a printer, please include this{" "}
+                If you have access to a printer, please include this{" "}
                 <a
                   target="_blank"
                   rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
Add an alert to the map about the new reimbursement policy at request of the Finance WG.

Message from Nikita:

> Temporary reimbursement policy change: There is a weekly cap for the disbursement of ioby raised funds. The amount available and left each week from ioby funds can be seen here. Ioby funds will be disbursed in order of requests received. Internal slack crowdsourcing and the CHMA hat are not included in the cap though!
> [Why is this happening? This is a temporary measure so that we can stretch our funding a little longer. More details here.]

Since the message is quite long, I decided to make it expandable. It is rendered in an alert component for visibility.

## Screenshots

Initial view: ![Screen Shot 2021-05-09 at 7 51 57 PM](https://user-images.githubusercontent.com/1868400/117592241-d74c8080-b105-11eb-9945-ef9bc6aae323.png)

When expanded:
![Screen Shot 2021-05-09 at 7 52 00 PM](https://user-images.githubusercontent.com/1868400/117592239-d74c8080-b105-11eb-9955-1d809cff0eb4.png)
